### PR TITLE
Add VS Code syntax file and grammar doc

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+output/

--- a/docs/grammar.html
+++ b/docs/grammar.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<html lang="fr">
+<head>
+<meta charset="UTF-8">
+<title>Grammaire du langage de tests</title>
+<style>
+body { font-family: Arial, sans-serif; margin: 2em; }
+h1 { color: #333; }
+code { background: #f4f4f4; padding: 2px 4px; }
+pre { background: #f4f4f4; padding: 1em; }
+</style>
+</head>
+<body>
+<h1>Rédiger des tests fonctionnels en langage naturel</h1>
+<p>Ce projet permet de décrire des scénarios de tests dans un français simple puis de générer un script shell correspondant. Chaque ligne d'un fichier de test suit la forme&nbsp;:</p>
+<pre><code>Action: &lt;description de l'&eacute;tape&gt; ; Resultat: &lt;r&eacute;sultat attendu&gt;</code></pre>
+<h2>Verbes et &eacute;l&eacute;ments reconnus</h2>
+<ul>
+  <li><strong>Initialisation</strong> : <code>initialiser</code>, <code>créer</code>, <code>configurer</code></li>
+  <li><strong>Ex&eacute;cution</strong> : <code>exécuter</code>, <code>lancer</code>, <code>traiter</code></li>
+  <li><strong>Validation</strong> : <code>vérifier</code>, <code>valider</code></li>
+  <li><strong>Fichiers</strong> : <code>toucher</code>, <code>cat</code>, <code>créer fichier/dossier</code></li>
+</ul>
+<p>Des param&egrave;tres optionnels peuvent &ecirc;tre ajout&eacute;s sur les lignes&nbsp;:</p>
+<ul>
+  <li><code>argument NOM=VALEUR</code> &ndash; ajoute un argument au batch</li>
+  <li><code>chemin des logs = /chemin/fichier.log</code></li>
+  <li><code>script sql = fichier.sql</code></li>
+  <li><code>créer ou mettre à jour fichier/dossier = CHEMIN avec les droits = MODE</code></li>
+  <li><code>toucher le fichier CHEMIN [-t TIMESTAMP]</code></li>
+</ul>
+<h2>Exemple complet</h2>
+<pre><code>Action: toucher le fichier /tmp/init.flag 202501010000 ; Resultat: fichier initialisé
+Action: exécuter /opt/batch/traitement.sh avec argument produit=42 ; Resultat: traitement réalisé
+Action: vérifier qu'il n'y a pas d'erreurs dans les logs ; Resultat: aucun message d'erreur</code></pre>
+<h2>Utilisation</h2>
+<ol>
+  <li>Cr&eacute;ez vos fichiers de test dans le dossier <code>tests/</code> en suivant la forme ci-dessus.</li>
+  <li>Lancez <code>python generate_tests.py --batch-path /chemin/vers/batch.sh</code>. Chaque fichier <code>.txt</code> g&eacute;n&egrave;re un script shell dans le dossier <code>output/</code>.</li>
+  <li>Ex&eacute;cutez ensuite le script shell g&eacute;n&eacute;r&eacute; pour reproduire les &eacute;tapes.</li>
+</ol>
+<p>Un fichier <code>syntaxes/nltest.tmLanguage.json</code> est fourni pour ajouter une coloration syntaxique dans Visual Studio Code.</p>
+</body>
+</html>

--- a/generate_tests.py
+++ b/generate_tests.py
@@ -1,144 +1,134 @@
-import re
+from parser import Parser
+from string import Template
+import argparse
+import os
+from glob import glob
 
-def parse_test_in_natural_language(test_description):
-    """
-    Cette fonction analyse la description en langage naturel du test et 
-    extrait les étapes nécessaires pour créer un playbook Ansible, y compris 
-    les chemins des fichiers logs, les scripts SQL, les commandes touch pour les dates,
-    et l'action pour afficher le contenu d'un fichier.
-    """
-    actions = {
-        "initialization": [],
-        "execution": [],
-        "validation": [],
-        "logs_check": [],
-        "arguments": {},
-        "log_paths": [],
-        "sql_scripts": [],
-        "file_operations": [],
-        "cat_files": []  # Pour l'action cat (afficher le contenu d'un fichier)
-    }
 
-    # Expressions régulières pour détecter les actions
-    if re.search(r"(initialiser|créer|configurer)", test_description, re.IGNORECASE):
-        actions["initialization"].append(test_description)
+def parse_test_in_natural_language(test_description: str):
+    """Analyse la description du test en utilisant le parseur modulaire."""
+    parser = Parser()
+    return parser.parse(test_description)
 
-    if re.search(r"(exécuter|lancer|traiter)", test_description, re.IGNORECASE):
-        actions["execution"].append(test_description)
 
-    if re.search(r"(vérifier|valider)", test_description, re.IGNORECASE):
-        actions["validation"].append(test_description)
+TEMPLATES = {
+    "process_batch": Template("${path} ${args}"),
+    "grep_log": Template("grep 'ERROR' ${path}"),
+    "execute_sql": Template("sqlplus -S user/password@db @${script}"),
+    "create_dir": Template("mkdir -p ${path} && chmod ${mode} ${path}"),
+    "create_file": Template("touch ${path} && chmod ${mode} ${path}"),
+    "update_file": Template("touch ${path}"),
+    "touch_ts": Template("touch -t ${ts} ${path}"),
+    "cat_file": Template("cat ${file}"),
+}
 
-    if re.search(r"(logs|erreurs|fichiers de logs)", test_description, re.IGNORECASE):
-        actions["logs_check"].append(test_description)
 
-    # Recherche des arguments pour le batch
-    match = re.search(r"(argument|paramètre) (.*)=(.*)", test_description)
-    if match:
-        actions["arguments"][match.group(2).strip()] = match.group(3).strip()
+def generate_shell_script(actions, batch_path: str):
+    """Génère un script shell à partir des actions extraites."""
+    lines = [
+        "#!/bin/bash",
+        "",
+        "log_diff() {",
+        "  expected=\"$1\"",
+        "  actual=\"$2\"",
+        "  if [ \"$expected\" != \"$actual\" ]; then",
+        "    echo 'Différence détectée :'",
+        "    echo \"- Attendu : $expected\"",
+        "    echo \"- Obtenu : $actual\"",
+        "  fi",
+        "}",
+        "",
+    ]
 
-    # Recherche des chemins de logs spécifiés dans le test
-    log_paths_matches = re.findall(r"(chemin|path) des logs\s*=\s*(\S+)", test_description, re.IGNORECASE)
-    if log_paths_matches:
-        actions["log_paths"] = [path for _, path in log_paths_matches]
-
-    # Recherche des scripts SQL pour Oracle
-    sql_scripts = re.findall(r"(script sql) = (.*\.sql)", test_description, re.IGNORECASE)
-    if sql_scripts:
-        actions["sql_scripts"] = [script for _, script in sql_scripts]
-
-    # Recherche des opérations sur les fichiers et dossiers avec les droits Unix
-    file_operations = re.findall(r"(créer|mettre à jour) (fichier|dossier)\s*=\s*(\S+)\s*(avec les droits|mode)\s*=\s*(\S+)", test_description, re.IGNORECASE)
-    if file_operations:
-        actions["file_operations"] = [(op, path, mode) for op, _, path, _, mode in file_operations]
-
-    # Recherche de l'action "cat" (afficher le contenu d'un fichier)
-    cat_files = re.findall(r"afficher le contenu du fichier\s*=\s*(\S+)", test_description, re.IGNORECASE)
-    if cat_files:
-        actions["cat_files"] = cat_files
-
-    return actions
-
-def generate_ansible_playbook_with_args(actions):
-    """
-    Cette fonction génère un playbook Ansible à partir des actions extraites et des arguments dynamiques.
-    Elle inclut aussi la gestion des scripts SQL, la création de fichiers/dossiers avec les droits Unix, 
-    les commandes touch, et l'action pour afficher le contenu d'un fichier.
-    """
-    playbook = """
----
-- name: Playbook généré à partir du test en langage naturel avec arguments, scripts SQL, et gestion de fichiers
-  hosts: localhost
-  tasks:
-  """
-
-    # Générer la partie d'initialisation
     if actions["initialization"]:
-        playbook += "\n    # Initialisation de l'environnement"
+        lines.append("# Initialisation")
         for action in actions["initialization"]:
-            playbook += f"\n    - name: {action}\n      debug:\n        msg: 'Initialisation effectuée'"
-    
-    # Générer la partie d'exécution avec arguments
+            lines.append(f"echo '{action}'  # TODO: implémenter la commande")
+        lines.append("")
+
     if actions["execution"]:
-        playbook += "\n    # Exécution du batch avec des arguments"
+        lines.append("# Exécution du batch")
+        arg_str = ' '.join([f'{k}={v}' for k, v in actions["arguments"].items()])
+        actual_path = actions.get("batch_path") or batch_path
         for action in actions["execution"]:
-            arg_str = ' '.join([f'{key}={value}' for key, value in actions["arguments"].items()])
-            playbook += f"\n    - name: {action}\n      command: './process_batch.sh {arg_str}'"
-    
-    # Générer la partie de validation
-    if actions["validation"]:
-        playbook += "\n    # Validation des résultats"
-        for action in actions["validation"]:
-            playbook += f"\n    - name: {action}\n      assert:\n        that:\n          - result == 'OK'"
-    
-    # Générer la vérification des logs avec chemins spécifiés
-    if actions["logs_check"]:
-        playbook += "\n    # Vérification des logs"
-        for log_path in actions["log_paths"]:
-            playbook += f"\n    - name: Vérifier les erreurs dans les logs {log_path}\n      shell: grep 'ERROR' {log_path}"
+            lines.append(f"echo '{action}'")
+            lines.append(TEMPLATES["process_batch"].substitute(path=actual_path, args=arg_str))
+        lines.append("")
 
-    # Générer l'exécution des scripts SQL pour Oracle
     if actions["sql_scripts"]:
-        playbook += "\n    # Exécution des scripts SQL"
+        lines.append("# Exécution des scripts SQL")
         for script in actions["sql_scripts"]:
-            playbook += f"\n    - name: Exécuter le script SQL {script}\n      command: 'sqlplus -S user/password@db @{script}'"
-    
-    # Générer la création des fichiers/dossiers avec les droits Unix et mise à jour de date avec touch
+            lines.append(TEMPLATES["execute_sql"].substitute(script=script))
+        lines.append("")
+
     if actions["file_operations"]:
-        playbook += "\n    # Création de fichiers et dossiers avec les droits Unix et mise à jour de date avec touch"
-        for operation, path, mode in actions["file_operations"]:
-            if "dossier" in operation.lower():
-                playbook += f"\n    - name: Créer le dossier {path} avec les droits {mode}\n      file:\n        path: {path}\n        state: directory\n        mode: '{mode}'"
-            if "fichier" in operation.lower():
-                playbook += f"\n    - name: Créer le fichier {path} avec les droits {mode}\n      file:\n        path: {path}\n        state: touch\n        mode: '{mode}'"
-            playbook += f"\n    - name: Mettre à jour la date du fichier {path}\n      shell: touch {path}"
+        lines.append("# Opérations sur les fichiers et dossiers")
+        for operation, ftype, path, mode in actions["file_operations"]:
+            if ftype.lower() == "dossier":
+                lines.append(TEMPLATES["create_dir"].substitute(path=path, mode=mode))
+            if ftype.lower() == "fichier":
+                lines.append(TEMPLATES["create_file"].substitute(path=path, mode=mode))
+            lines.append(TEMPLATES["update_file"].substitute(path=path))
+        lines.append("")
 
-    # Ajouter l'action "afficher le contenu du fichier"
+    if actions.get("touch_files"):
+        lines.append("# Mise à jour de fichiers")
+        for entry in actions["touch_files"]:
+            if isinstance(entry, tuple):
+                path, ts = entry
+            else:
+                path, ts = entry, None
+            if ts:
+                lines.append(TEMPLATES["touch_ts"].substitute(path=path, ts=ts))
+            else:
+                lines.append(TEMPLATES["update_file"].substitute(path=path))
+        lines.append("")
+
     if actions["cat_files"]:
-        playbook += "\n    # Afficher le contenu du fichier"
+        lines.append("# Affichage du contenu des fichiers")
         for file in actions["cat_files"]:
-            playbook += f"\n    - name: Afficher le contenu du fichier {file}\n      shell: cat {file}"
+            lines.append(TEMPLATES["cat_file"].substitute(file=file))
+        lines.append("")
 
-    playbook += "\n"
+    if actions["logs_check"]:
+        lines.append("# Vérification des logs")
+        for path in actions["log_paths"]:
+            lines.append(TEMPLATES["grep_log"].substitute(path=path))
+        lines.append("")
 
-    return playbook
+    if actions["validation"]:
+        lines.append("# Validation des résultats")
+        for expected in actions["validation"]:
+            lines.append(f"# Attendu : {expected}")
+            lines.append("actual=\"<commande à implémenter>\"")
+            lines.append(f"expected=\"{expected}\"")
+            lines.append("log_diff \"$expected\" \"$actual\"")
+            lines.append("")
+
+    return "\n".join(lines)
+
+
+INPUT_DIR = "tests"
+OUTPUT_DIR = "output"
+
 
 def main():
-    # Exemple de test en langage naturel avec des arguments dynamiques, des chemins de logs, SQL, opérations de fichiers et cat
-    test_description = """
-    Initialiser la base de données avec des données de test en exécutant le script JDD_Commun.sql.
-    Afficher le contenu du fichier = /tmp/JDD_Commun.sql
-    Vérifier que les données ont été correctement insérées dans la base de données.
-    """
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--batch-path", default="./process_batch.sh", help="Chemin vers le script batch")
+    args = parser.parse_args()
 
-    # Étape 1 : Analyser la description du test
-    actions = parse_test_in_natural_language(test_description)
-    
-    # Étape 2 : Générer le playbook Ansible
-    playbook = generate_ansible_playbook_with_args(actions)
-    
-    # Étape 3 : Afficher le playbook généré
-    print(playbook)
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+    for txt_file in glob(os.path.join(INPUT_DIR, "*.txt")):
+        with open(txt_file, encoding="utf-8") as f:
+            test_description = f.read()
+        actions = parse_test_in_natural_language(test_description)
+        script = generate_shell_script(actions, batch_path=args.batch_path)
+        out_name = os.path.splitext(os.path.basename(txt_file))[0] + ".sh"
+        out_path = os.path.join(OUTPUT_DIR, out_name)
+        with open(out_path, "w", encoding="utf-8") as f:
+            f.write(script)
+        print(f"Generated {out_path}")
 
-if __name__ == "__main__":
+
+if __name__ == '__main__':
     main()

--- a/parser.py
+++ b/parser.py
@@ -1,0 +1,96 @@
+"""Utility module to parse natural language test descriptions."""
+
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Tuple, Optional, Any
+import re
+
+@dataclass
+class Rule:
+    pattern: re.Pattern
+    handler: Callable[[re.Match, Dict[str, Any]], None]
+
+class Parser:
+    """A modular parser based on a set of regex rules."""
+
+    def __init__(self) -> None:
+        self.rules: List[Rule] = []
+        self.action_result_re: Optional[re.Pattern] = None
+        self._register_default_rules()
+
+    def _register(self, pattern: str, handler: Callable[[re.Match, Dict[str, List]], None]) -> None:
+        compiled = re.compile(pattern, re.IGNORECASE)
+        self.rules.append(Rule(compiled, handler))
+
+    def _register_default_rules(self) -> None:
+        # Action/Result grammar should be evaluated first
+        pattern = r"Action\s*:\s*(.*?)\s*(?:Résultat|Resultat)\s*:?\s*(.*)"
+        self.action_result_re = re.compile(pattern, re.IGNORECASE)
+        self._register(pattern, self._handle_action_result)
+
+        # Simple actions
+        self._register(r"(initialiser|créer|configurer)",
+                       lambda m, a: a["initialization"].append(m.string.strip()))
+        self._register(r"(exécuter|lancer|traiter)",
+                       lambda m, a: a["execution"].append(m.string.strip()))
+        self._register(r"(?:vérifier|valider)\s+que\s+(.*)",
+                       lambda m, a: a["validation"].append(m.group(1).rstrip('.').strip()))
+        self._register(r"(logs|erreurs|fichiers de logs)",
+                       lambda m, a: a["logs_check"].append(m.string.strip()))
+
+        # Dynamic extractions
+        self._register(r"(?:argument|paramètre)\s+(\S+)\s*=\s*(\S+)",
+                       lambda m, a: a["arguments"].__setitem__(m.group(1).strip(), m.group(2).strip()))
+        self._register(r"(?:chemin|path) des logs\s*=\s*(\S+)",
+                       lambda m, a: a["log_paths"].append(m.group(1)))
+        self._register(r"script sql\s*=\s*(.*?\.sql)",
+                       lambda m, a: a["sql_scripts"].append(m.group(1)))
+        self._register(r"(créer|mettre à jour) (?:le\s+)?(fichier|dossier)\s*=\s*(\S+)\s*(?:avec les droits|mode)\s*=\s*(\S+)",
+                       lambda m, a: a["file_operations"].append((m.group(1), m.group(2), m.group(3), m.group(4))))
+        self._register(r"mettre à jour la date du fichier\s*(\S+)\s*(\d{8,14})?",
+                       lambda m, a: a["touch_files"].append((m.group(1), m.group(2))))
+        self._register(r"touch(?:er)?(?:\s+le\s+fichier)?\s*(\S+)(?:\s+(?:-t\s*)?(\d{8,14}))?",
+                       lambda m, a: a["touch_files"].append((m.group(1), m.group(2))))
+        self._register(r"exécuter\s+(\/\S+\.sh)",
+                       lambda m, a: a.__setitem__("batch_path", m.group(1)))
+        self._register(r"(?:afficher le contenu du fichier|cat le fichier)\s*=\s*(\S+)",
+                       lambda m, a: a["cat_files"].append(m.group(1)))
+
+    def _handle_action_result(self, match: re.Match, actions: Dict[str, List]) -> None:
+        """Parse a line written as 'Action: ... Resultat: ...'."""
+        sub_parser = Parser()
+        sub_actions = sub_parser.parse(match.group(1))
+        for key, value in sub_actions.items():
+            if key == "batch_path" and value:
+                actions[key] = value
+            elif isinstance(value, dict):
+                actions[key].update(value)
+            elif isinstance(value, list):
+                actions[key].extend(value)
+        result = match.group(2).rstrip('.').strip()
+        if result:
+            actions["validation"].append(result)
+
+    def parse(self, description: str) -> Dict[str, Any]:
+        actions: Dict[str, List] = {
+            "initialization": [],
+            "execution": [],
+            "validation": [],
+            "logs_check": [],
+            "arguments": {},
+            "log_paths": [],
+            "sql_scripts": [],
+            "file_operations": [],
+            "cat_files": [],
+            "touch_files": [],
+            "batch_path": None,
+        }
+
+        for line in description.splitlines():
+            for rule in self.rules:
+                match = rule.pattern.search(line)
+                if match:
+                    rule.handler(match, actions)
+                    if self.action_result_re and rule.pattern.pattern == self.action_result_re.pattern:
+                        break
+
+        return actions

--- a/syntaxes/nltest.tmLanguage.json
+++ b/syntaxes/nltest.tmLanguage.json
@@ -1,0 +1,11 @@
+{
+  "scopeName": "source.nltest",
+  "patterns": [
+    {"match": "\\bAction\\b", "name": "keyword.other.action.nltest"},
+    {"match": "\\b(Résultat|Resultat)\\b", "name": "keyword.other.result.nltest"},
+    {"match": "\\b(initialiser|créer|configurer|exécuter|lancer|traiter|vérifier|valider|toucher|cat)\\b", "name": "keyword.control.nltest"},
+    {"match": "\\b(argument|paramètre|chemin|path|script sql)\\b", "name": "storage.type.nltest"},
+    {"match": "\\b\\d{8,14}\\b", "name": "constant.numeric.timestamp.nltest"},
+    {"match": "/[\\w/\\.\\-]+", "name": "string.unquoted.path.nltest"}
+  ]
+}

--- a/tests/test_case_1.txt
+++ b/tests/test_case_1.txt
@@ -1,5 +1,3 @@
-
-    Initialiser la base de données avec des données de test en exécutant le script JDD_Commun.sql.
-    Afficher le contenu du fichier = /tmp/JDD_Commun.sql
-    Vérifier que les données ont été correctement insérées dans la base de données.
-    
+Action: toucher le fichier /tmp/init.flag 202501010000 ; Resultat: fichier initialisé
+Action: initialiser la base de données en exécutant JDD_Commun.sql ; Resultat: base de test prête
+Action: afficher le contenu du fichier = /tmp/JDD_Commun.sql ; Resultat: contenu affiché

--- a/tests/test_case_2.txt
+++ b/tests/test_case_2.txt
@@ -1,6 +1,3 @@
-
-    Exécuter le script de traitement des commandes avec argument produit=123 et quantité=10.
-    Vérifier que la commande est marquée comme traitée dans la base de données.
-    Vérifier qu'il n'y a pas d'erreurs dans les logs.
-    Chemin des logs = /var/log/system.log
-    
+Action: exécuter /opt/batch/traitement.sh avec argument produit=123 et quantité=10 ; Resultat: commande traitée
+Action: vérifier qu'il n'y a pas d'erreurs dans les logs ; Resultat: aucun message d'erreur
+Action: chemin des logs = /var/log/system.log ; Resultat: logs accessibles

--- a/tests/test_case_3.txt
+++ b/tests/test_case_3.txt
@@ -1,5 +1,2 @@
-
-    Initialiser la base de données en exécutant JDD_Commun.sql et ajouter des données supplémentaires avec JDD_Extra.sql.
-    Vérifier que les données ont été insérées dans la base et que la base de données est prête pour le test.
-    Afficher le contenu du fichier = /tmp/JDD_Extra.sql
-    
+Action: initialiser la base avec JDD_Commun.sql puis JDD_Extra.sql ; Resultat: base prête pour le test
+Action: afficher le contenu du fichier = /tmp/JDD_Extra.sql ; Resultat: script affiché

--- a/tests/test_case_4.txt
+++ b/tests/test_case_4.txt
@@ -1,7 +1,4 @@
-
-    Créer le dossier = /tmp/data avec les droits = 0755
-    Créer fichier = /tmp/output.txt avec les droits = 0644
-    Mettre à jour la date du fichier /tmp/output.txt
-    Cat le fichier = /tmp/output.txt
-    Vérifier que le fichier contient les données attendues.
-    
+Action: créer le dossier = /tmp/data avec les droits = 0755 ; Resultat: dossier créé
+Action: créer fichier = /tmp/output.txt avec les droits = 0644 ; Resultat: fichier présent
+Action: mettre à jour la date du fichier /tmp/output.txt 202501021200 ; Resultat: date modifiée
+Action: cat le fichier = /tmp/output.txt ; Resultat: contenu correct

--- a/tests/test_case_5.txt
+++ b/tests/test_case_5.txt
@@ -1,7 +1,4 @@
-
-    Initialiser le serveur avec les configurations par défaut.
-    Exécuter le batch de traitement des commandes avec argument produit=567 et quantité=20.
-    Vérifier les logs pour s'assurer que le traitement s'est bien effectué.
-    Afficher les logs d'exécution = /var/log/batch.log
-    Vérifier que l'API renvoie le bon statut pour les commandes traitées.
-    
+Action: initialiser le serveur avec les configurations par défaut ; Resultat: serveur démarré
+Action: exécuter /opt/batch/traitement.sh avec argument produit=567 et quantité=20 ; Resultat: traitement réalisé
+Action: afficher les logs d'exécution = /var/log/batch.log ; Resultat: logs affichés
+Action: vérifier que l'API renvoie le bon statut ; Resultat: statut OK

--- a/tests/test_case_6.txt
+++ b/tests/test_case_6.txt
@@ -1,7 +1,3 @@
-
-    Créer un dossier temporaire pour les tests dans /tmp/test_folder avec les droits = 0700.
-    Créer un fichier temporaire de test dans /tmp/test_folder/test.txt avec les droits = 0600.
-    Afficher le contenu du fichier = /tmp/test_folder/test.txt
-    Cat le fichier = /tmp/test_folder/test.txt
-    Vérifier que le fichier contient les informations correctes pour le test.
-    
+Action: créer le dossier = /tmp/test_folder avec les droits = 0700 ; Resultat: dossier prêt
+Action: créer fichier = /tmp/test_folder/test.txt avec les droits = 0600 ; Resultat: fichier créé
+Action: cat le fichier = /tmp/test_folder/test.txt ; Resultat: contenu lisible


### PR DESCRIPTION
## Summary
- create VS Code TextMate grammar for the natural language test format
- add HTML documentation describing the grammar
- expand grammar documentation so anyone can create tests

## Testing
- `python -m py_compile parser.py generate_tests.py`
- `python generate_tests.py | head -n 20`


------
https://chatgpt.com/codex/tasks/task_e_68568a36d5148331aa28468eb0382092