### PR TITLE
Implement Excel export option

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,3 +24,13 @@ vsce package
 
 This will create `shtest-syntax-0.0.1.vsix` which can then be installed in VS
 Code.
+
+## Exporting tests to Excel
+
+Use `export_to_excel.py` to convert `.shtest` files into an Excel summary. Each row corresponds to a step of a test with columns for the test name, actions, expected results and actual results.
+
+```bash
+python src/export_to_excel.py --input-dir src/tests --output tests_summary.xlsx
+```
+
+This generates `tests_summary.xlsx` in the current directory.

--- a/src/export_to_excel.py
+++ b/src/export_to_excel.py
@@ -1,0 +1,57 @@
+import argparse
+import os
+import re
+from glob import glob
+from openpyxl import Workbook
+
+
+def parse_shtest_file(path: str):
+    step_re = re.compile(r"^(?:Étape|Etape|Step)\s*:\s*(.*)", re.IGNORECASE)
+    action_re = re.compile(r"^Action\s*:\s*(.*?)\s*;\s*(?:Résultat|Resultat)\s*:?\s*(.*)", re.IGNORECASE)
+    steps = []
+    current = {"name": "", "actions": [], "expected": [], "obtained": []}
+    with open(path, encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            m = step_re.match(line)
+            if m:
+                if current["actions"] or current["expected"]:
+                    steps.append(current)
+                current = {"name": m.group(1).strip(), "actions": [], "expected": [], "obtained": []}
+                continue
+            m = action_re.match(line)
+            if m:
+                current["actions"].append(m.group(1).strip())
+                current["expected"].append(m.group(2).strip())
+    if current["actions"] or current["expected"]:
+        steps.append(current)
+    return steps
+
+
+def export_tests_to_excel(input_dir: str, output_file: str) -> None:
+    wb = Workbook()
+    ws = wb.active
+    ws.title = "Tests"
+    ws.append(["Test Name", "Actions", "Expected Results", "Actual Results"])
+
+    for path in glob(os.path.join(input_dir, "*.shtest")):
+        test_name = os.path.splitext(os.path.basename(path))[0]
+        for step in parse_shtest_file(path):
+            actions = "\n".join(step["actions"])
+            if step["name"]:
+                actions = f"Step: {step['name']}\n" + actions
+            expected = "\n".join(step["expected"])
+            obtained = "\n".join(step["obtained"])
+            ws.append([test_name, actions, expected, obtained])
+
+    wb.save(output_file)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Export .shtest files to an Excel summary")
+    parser.add_argument("--input-dir", default="tests", help="Directory containing .shtest files")
+    parser.add_argument("--output", default="tests_summary.xlsx", help="Path to the output Excel file")
+    args = parser.parse_args()
+    export_tests_to_excel(args.input_dir, args.output)


### PR DESCRIPTION
## Summary
- add `export_to_excel.py` for converting `.shtest` files to an XLSX summary
- document the new export script in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python src/export_to_excel.py --input-dir src/tests --output tests_summary.xlsx`

------
https://chatgpt.com/codex/tasks/task_e_6856a0b182a883319a871406445e79cf