### PR TITLE
Add AST generation for validations

### DIFF
--- a/src/generate_tests.py
+++ b/src/generate_tests.py
@@ -1,7 +1,8 @@
 """Utilities to transform ``.shtest`` files into executable shell scripts."""
 
-from parser import Parser, AliasResolver
-from string import Template
+from parser import Parser
+from templates import TEMPLATES
+from validation_compiler import _compile_validation
 import argparse
 import os
 from glob import glob
@@ -27,138 +28,6 @@ def parse_test_file(contents: str):
     return parsed_lines
 
 
-TEMPLATES = {
-    "process_batch": Template("${path} ${args}"),
-    "grep_log": Template("grep 'ERROR' ${path}"),
-    "execute_sql": Template("sqlplus -S user/password@db @${script}"),
-    "create_dir": Template("mkdir -p ${path} && chmod ${mode} ${path}"),
-    "create_file": Template("touch ${path} && chmod ${mode} ${path}"),
-    "update_file": Template("touch ${path}"),
-    "touch_ts": Template("touch -t ${ts} ${path}"),
-    "cat_file": Template("cat ${file}"),
-    "copy_file": Template("cp ${src} ${dest}"),
-    "copy_dir": Template("cp -r ${src} ${dest}"),
-    "move": Template("mv ${src} ${dest}"),
-}
-
-
-def _tokenize_expression(expr: str):
-    """Split a validation expression into tokens."""
-
-    tokens = [t.strip() for t in re.split(r"(\bet\b|\bou\b|\(|\))", expr) if t.strip()]
-    return tokens
-
-
-def _to_postfix(tokens):
-    """Convert infix tokens to postfix notation using the shunting-yard algorithm."""
-
-    precedence = {"et": 2, "ou": 1}
-    output = []
-    stack = []
-    for tok in tokens:
-        ltok = tok.lower()
-        if ltok in precedence:
-            while stack and stack[-1].lower() in precedence and precedence[stack[-1].lower()] >= precedence[ltok]:
-                output.append(stack.pop())
-            stack.append(ltok)
-        elif tok == "(":
-            stack.append(tok)
-        elif tok == ")":
-            while stack and stack[-1] != "(":
-                output.append(stack.pop())
-            if stack and stack[-1] == "(":
-                stack.pop()
-        else:
-            output.append(tok)
-    while stack:
-        output.append(stack.pop())
-    return output
-
-
-def _compile_atomic(expected: str, varname: str, last_file_var: list):
-    """Compile a single validation expression into shell code."""
-
-    lines = [f"# Attendu : {expected}"]
-    m = re.search(r"le fichier (\S+) existe", expected, re.IGNORECASE)
-    if m:
-        last_file_var[0] = m.group(1)
-        lines.append(f"if [ -e {last_file_var[0]} ]; then actual=\"le fichier {last_file_var[0]} existe\"; else actual=\"le fichier {last_file_var[0]} absent\"; fi")
-        lines.append(f"expected=\"le fichier {last_file_var[0]} existe\"")
-    elif re.search(r"(?:le\s+)?fichier\s+est\s+présent", expected, re.IGNORECASE) and last_file_var[0]:
-        lines.append(f"if [ -e {last_file_var[0]} ]; then actual=\"Le fichier est présent\"; else actual=\"fichier absent\"; fi")
-        lines.append("expected=\"Le fichier est présent\"")
-    elif re.search(r"le\s+(fichier|dossier)\s+est\s+copié", expected, re.IGNORECASE):
-        lines.append(f"if [ $last_ret -eq 0 ]; then actual=\"{expected}\"; else actual=\"échec copie\"; fi")
-        lines.append(f"expected=\"{expected}\"")
-    else:
-        ret_match = re.search(r"retour\s*(\d+)", expected)
-        if ret_match:
-            lines.append("actual=\"$last_ret\"")
-            lines.append(f"expected=\"{ret_match.group(1)}\"")
-        else:
-            stdout_match = re.search(r"stdout\s*=\s*(.*)", expected)
-            if stdout_match:
-                lines.append("actual=\"$last_stdout\"")
-                lines.append(f"expected=\"{stdout_match.group(1)}\"")
-            else:
-                stdout_grep = re.search(r"stdout\s+contient\s+(.*)", expected)
-                if stdout_grep:
-                    pattern = stdout_grep.group(1)
-                    lines.append(f"if echo \"$last_stdout\" | grep -q {pattern!r}; then actual={pattern!r}; else actual=\"\"; fi")
-                    lines.append(f"expected={pattern!r}")
-                else:
-                    stderr_match = re.search(r"stderr\s*=\s*(.*)", expected)
-                    if stderr_match:
-                        lines.append("actual=\"$last_stderr\"")
-                        lines.append(f"expected=\"{stderr_match.group(1)}\"")
-                    else:
-                        stderr_grep = re.search(r"stderr\s+contient\s+(.*)", expected)
-                        if stderr_grep:
-                            pattern = stderr_grep.group(1)
-                            lines.append(f"if echo \"$last_stderr\" | grep -q {pattern!r}; then actual={pattern!r}; else actual=\"\"; fi")
-                            lines.append(f"expected={pattern!r}")
-                        else:
-                            lines.append("actual=\"non vérifié\"")
-                            lines.append(f"expected=\"{expected}\"")
-    lines.append("log_diff \"$expected\" \"$actual\"")
-    lines.append(f"if [ \"$expected\" = \"$actual\" ]; then {varname}=1; else {varname}=0; fi")
-    return lines
-
-
-def _compile_validation(expression: str):
-    """Compile a complex validation expression into shell instructions."""
-
-    if re.search(r"\bet\b|\bou\b|\(|\)", expression):
-        resolver = AliasResolver()
-        tokens = _tokenize_expression(expression)
-        tokens = [resolver.resolve(t)[0] if t not in ("et", "ou", "(", ")") else t for t in tokens]
-        postfix = _to_postfix(tokens)
-        lines = []
-        stack = []
-        counter = 0
-        last_file_var = [None]
-        for tok in postfix:
-            if tok in ("et", "ou"):
-                b = stack.pop()
-                a = stack.pop()
-                counter += 1
-                var = f"cond{counter}"
-                op = "&&" if tok == "et" else "||"
-                lines.append(f"if [ ${{{a}}} -eq 1 ] {op} [ ${{{b}}} -eq 1 ]; then {var}=1; else {var}=0; fi")
-                stack.append(var)
-            else:
-                counter += 1
-                var = f"cond{counter}"
-                lines.extend(_compile_atomic(tok, var, last_file_var))
-                stack.append(var)
-        final_var = stack.pop()
-        lines.append(f"if [ ${{{final_var}}} -eq 1 ]; then actual=\"OK\"; else actual=\"KO\"; fi")
-        lines.append("expected=\"OK\"")
-        lines.append("log_diff \"$expected\" \"$actual\"")
-        return lines
-    else:
-        last_file_var = [None]
-        return _compile_atomic(expression, "cond0", last_file_var)
 
 
 def generate_shell_script(actions_list, batch_path: str):

--- a/src/templates.py
+++ b/src/templates.py
@@ -1,0 +1,16 @@
+from string import Template
+
+TEMPLATES = {
+    "process_batch": Template("${path} ${args}"),
+    "grep_log": Template("grep 'ERROR' ${path}"),
+    "execute_sql": Template("sqlplus -S user/password@db @${script}"),
+    "create_dir": Template("mkdir -p ${path} && chmod ${mode} ${path}"),
+    "create_file": Template("touch ${path} && chmod ${mode} ${path}"),
+    "update_file": Template("touch ${path}"),
+    "touch_ts": Template("touch -t ${ts} ${path}"),
+    "cat_file": Template("cat ${file}"),
+    "copy_file": Template("cp ${src} ${dest}"),
+    "copy_dir": Template("cp -r ${src} ${dest}"),
+    "move": Template("mv ${src} ${dest}"),
+}
+

--- a/src/validation_ast.py
+++ b/src/validation_ast.py
@@ -1,0 +1,66 @@
+from dataclasses import dataclass
+from typing import List
+import re
+from parser import AliasResolver
+
+@dataclass
+class ASTNode:
+    pass
+
+@dataclass
+class Atomic(ASTNode):
+    value: str
+
+@dataclass
+class BinaryOp(ASTNode):
+    op: str  # 'et' or 'ou'
+    left: ASTNode
+    right: ASTNode
+
+
+def _tokenize_expression(expr: str) -> List[str]:
+    """Split a validation expression into tokens."""
+    return [t.strip() for t in re.split(r"(\bet\b|\bou\b|\(|\))", expr) if t.strip()]
+
+
+def _to_postfix(tokens: List[str]) -> List[str]:
+    """Convert infix tokens to postfix notation using the shunting-yard algorithm."""
+    precedence = {"et": 2, "ou": 1}
+    output: List[str] = []
+    stack: List[str] = []
+    for tok in tokens:
+        ltok = tok.lower()
+        if ltok in precedence:
+            while stack and stack[-1].lower() in precedence and precedence[stack[-1].lower()] >= precedence[ltok]:
+                output.append(stack.pop())
+            stack.append(ltok)
+        elif tok == "(":
+            stack.append(tok)
+        elif tok == ")":
+            while stack and stack[-1] != "(":
+                output.append(stack.pop())
+            if stack and stack[-1] == "(":
+                stack.pop()
+        else:
+            output.append(tok)
+    while stack:
+        output.append(stack.pop())
+    return output
+
+
+def parse_validation_expression(expression: str) -> ASTNode:
+    """Parse a validation expression into an AST."""
+    # Resolve aliases so that the AST only contains canonical forms
+    resolver = AliasResolver()
+    tokens = _tokenize_expression(expression)
+    tokens = [resolver.resolve(t)[0] if t not in ("et", "ou", "(", ")") else t for t in tokens]
+    postfix = _to_postfix(tokens)
+    stack: List[ASTNode] = []
+    for tok in postfix:
+        if tok in ("et", "ou"):
+            right = stack.pop()
+            left = stack.pop()
+            stack.append(BinaryOp(tok, left, right))
+        else:
+            stack.append(Atomic(tok))
+    return stack.pop() if stack else Atomic("")

--- a/src/validation_compiler.py
+++ b/src/validation_compiler.py
@@ -1,0 +1,92 @@
+import re
+from validation_ast import (
+    ASTNode,
+    Atomic,
+    BinaryOp,
+    parse_validation_expression,
+)
+
+
+
+
+def _compile_atomic(expected: str, varname: str, last_file_var: list):
+    """Compile a single validation expression into shell code."""
+    lines = [f"# Attendu : {expected}"]
+    m = re.search(r"le fichier (\S+) existe", expected, re.IGNORECASE)
+    if m:
+        last_file_var[0] = m.group(1)
+        lines.append(f"if [ -e {last_file_var[0]} ]; then actual=\"le fichier {last_file_var[0]} existe\"; else actual=\"le fichier {last_file_var[0]} absent\"; fi")
+        lines.append(f"expected=\"le fichier {last_file_var[0]} existe\"")
+    elif re.search(r"(?:le\s+)?fichier\s+est\s+présent", expected, re.IGNORECASE) and last_file_var[0]:
+        lines.append(f"if [ -e {last_file_var[0]} ]; then actual=\"Le fichier est présent\"; else actual=\"fichier absent\"; fi")
+        lines.append("expected=\"Le fichier est présent\"")
+    elif re.search(r"le\s+(fichier|dossier)\s+est\s+copié", expected, re.IGNORECASE):
+        lines.append(f"if [ $last_ret -eq 0 ]; then actual=\"{expected}\"; else actual=\"échec copie\"; fi")
+        lines.append(f"expected=\"{expected}\"")
+    else:
+        ret_match = re.search(r"retour\s*(\d+)", expected)
+        if ret_match:
+            lines.append("actual=\"$last_ret\"")
+            lines.append(f"expected=\"{ret_match.group(1)}\"")
+        else:
+            stdout_match = re.search(r"stdout\s*=\s*(.*)", expected)
+            if stdout_match:
+                lines.append("actual=\"$last_stdout\"")
+                lines.append(f"expected=\"{stdout_match.group(1)}\"")
+            else:
+                stdout_grep = re.search(r"stdout\s+contient\s+(.*)", expected)
+                if stdout_grep:
+                    pattern = stdout_grep.group(1)
+                    lines.append(f"if echo \"$last_stdout\" | grep -q {pattern!r}; then actual={pattern!r}; else actual=\"\"; fi")
+                    lines.append(f"expected={pattern!r}")
+                else:
+                    stderr_match = re.search(r"stderr\s*=\s*(.*)", expected)
+                    if stderr_match:
+                        lines.append("actual=\"$last_stderr\"")
+                        lines.append(f"expected=\"{stderr_match.group(1)}\"")
+                    else:
+                        stderr_grep = re.search(r"stderr\s+contient\s+(.*)", expected)
+                        if stderr_grep:
+                            pattern = stderr_grep.group(1)
+                            lines.append(f"if echo \"$last_stderr\" | grep -q {pattern!r}; then actual={pattern!r}; else actual=\"\"; fi")
+                            lines.append(f"expected={pattern!r}")
+                        else:
+                            lines.append("actual=\"non vérifié\"")
+                            lines.append(f"expected=\"{expected}\"")
+    lines.append("log_diff \"$expected\" \"$actual\"")
+    lines.append(f"if [ \"$expected\" = \"$actual\" ]; then {varname}=1; else {varname}=0; fi")
+    return lines
+
+
+def _compile_validation(expression: str):
+    """Compile a complex validation expression into shell instructions."""
+
+    def _compile_ast(node: ASTNode, counter: list, last_file_var: list):
+        if isinstance(node, BinaryOp):
+            left_lines, left_var = _compile_ast(node.left, counter, last_file_var)
+            right_lines, right_var = _compile_ast(node.right, counter, last_file_var)
+            counter[0] += 1
+            var = f"cond{counter[0]}"
+            op = "&&" if node.op == "et" else "||"
+            lines = left_lines + right_lines
+            lines.append(
+                f"if [ ${{{left_var}}} -eq 1 ] {op} [ ${{{right_var}}} -eq 1 ]; then {var}=1; else {var}=0; fi"
+            )
+            return lines, var
+        elif isinstance(node, Atomic):
+            counter[0] += 1
+            var = f"cond{counter[0]}"
+            lines = _compile_atomic(node.value, var, last_file_var)
+            return lines, var
+        else:
+            raise TypeError("Unknown AST node")
+
+    ast = parse_validation_expression(expression)
+    counter = [0]
+    last_file_var = [None]
+    lines, final_var = _compile_ast(ast, counter, last_file_var)
+    lines.append(f"if [ ${{{final_var}}} -eq 1 ]; then actual=\"OK\"; else actual=\"KO\"; fi")
+    lines.append("expected=\"OK\"")
+    lines.append("log_diff \"$expected\" \"$actual\"")
+    return lines
+


### PR DESCRIPTION
## Summary
- add new `validation_ast.py` module with dataclasses and parser
- compile validation expressions by building an AST before generating shell code

## Testing
- `python -m py_compile src/generate_tests.py src/templates.py src/validation_compiler.py src/validation_ast.py src/parser.py`
- `python src/generate_tests.py --batch-path ./process_batch.sh`

------
https://chatgpt.com/codex/tasks/task_e_685977e07664833186ff91d76690a4db