### PR TITLE
Add support for more result phrases

### DIFF
--- a/src/generate_tests.py
+++ b/src/generate_tests.py
@@ -9,12 +9,6 @@ from glob import glob
 import re
 
 
-def parse_test_in_natural_language(test_description: str):
-    """Analyse la description du test en utilisant le parseur modulaire."""
-    parser = Parser()
-    return parser.parse(test_description)
-
-
 def parse_test_file(contents: str):
     """Parse line by line and preserve ordering of actions/results."""
 

--- a/src/parser.py
+++ b/src/parser.py
@@ -62,6 +62,54 @@ class AliasResolver:
                 re.compile(r"le dossier\s+est\s+copié", re.IGNORECASE),
                 lambda m: ["le dossier est copié"]
             ),
+            (
+                re.compile(r"le fichier\s+est\s+initialis[ée]", re.IGNORECASE),
+                lambda m: ["Le fichier est présent"]
+            ),
+            (
+                re.compile(r"le fichier\s+est\s+cr[ée]", re.IGNORECASE),
+                lambda m: ["Le fichier est présent"]
+            ),
+            (
+                re.compile(r"la base(?: de test)?\s+est\s+pr[êe]te(?:\s+pour le test)?", re.IGNORECASE),
+                lambda m: ["base prête"]
+            ),
+            (
+                re.compile(r"le contenu\s+est\s+affich[ée]", re.IGNORECASE),
+                lambda m: ["contenu affiché"]
+            ),
+            (
+                re.compile(r"le script\s+est\s+affich[ée]", re.IGNORECASE),
+                lambda m: ["contenu affiché"]
+            ),
+            (
+                re.compile(r"le dossier\s+est\s+cr[ée]", re.IGNORECASE),
+                lambda m: ["dossier créé"]
+            ),
+            (
+                re.compile(r"le dossier\s+est\s+pr[êe]t", re.IGNORECASE),
+                lambda m: ["dossier créé"]
+            ),
+            (
+                re.compile(r"la date\s+est\s+modifi[ée]", re.IGNORECASE),
+                lambda m: ["date modifiée"]
+            ),
+            (
+                re.compile(r"le contenu\s+est\s+correct", re.IGNORECASE),
+                lambda m: ["contenu correct"]
+            ),
+            (
+                re.compile(r"le contenu\s+est\s+lisible", re.IGNORECASE),
+                lambda m: ["contenu affiché"]
+            ),
+            (
+                re.compile(r"aucun message d'?erreur", re.IGNORECASE),
+                lambda m: ["stderr="]
+            ),
+            (
+                re.compile(r"les logs sont accessibles", re.IGNORECASE),
+                lambda m: ["logs accessibles"]
+            ),
         ]
 
     def resolve(self, text: str) -> List[str]:

--- a/src/templates.py
+++ b/src/templates.py
@@ -1,7 +1,6 @@
 from string import Template
 
 TEMPLATES = {
-    "process_batch": Template("${path} ${args}"),
     "grep_log": Template("grep 'ERROR' ${path}"),
     "execute_sql": Template("sqlplus -S user/password@db @${script}"),
     "create_dir": Template("mkdir -p ${path} && chmod ${mode} ${path}"),

--- a/src/tests/alias_aucun_message_erreur.shtest
+++ b/src/tests/alias_aucun_message_erreur.shtest
@@ -1,0 +1,2 @@
+Action: Vérifier qu'il n'y a pas d'erreur ; Résultat: stderr=.
+Action: Vérifier qu'il n'y a pas d'erreur ; Résultat: aucun message d'erreur.

--- a/src/tests/alias_base_prete.shtest
+++ b/src/tests/alias_base_prete.shtest
@@ -1,0 +1,3 @@
+Action: Exécuter script.sh ; Résultat: base prête.
+Action: Exécuter script.sh ; Résultat: La base de test est prête.
+Action: Exécuter script.sh ; Résultat: La base est prête pour le test.

--- a/src/tests/alias_contenu_affiche.shtest
+++ b/src/tests/alias_contenu_affiche.shtest
@@ -1,0 +1,4 @@
+Action: Afficher le contenu du fichier = /tmp/test.txt ; Résultat: contenu affiché.
+Action: Afficher le contenu du fichier = /tmp/test.txt ; Résultat: Le contenu est affiché.
+Action: Afficher le contenu du fichier = /tmp/test.txt ; Résultat: Le script est affiché.
+Action: Afficher le contenu du fichier = /tmp/test.txt ; Résultat: le contenu est lisible.

--- a/src/tests/alias_contenu_correct.shtest
+++ b/src/tests/alias_contenu_correct.shtest
@@ -1,0 +1,2 @@
+Action: Afficher le contenu du fichier = /tmp/file.txt ; Résultat: contenu correct.
+Action: Afficher le contenu du fichier = /tmp/file.txt ; Résultat: Le contenu est correct.

--- a/src/tests/alias_date_modifiee.shtest
+++ b/src/tests/alias_date_modifiee.shtest
@@ -1,0 +1,2 @@
+Action: Mettre à jour la date du fichier /tmp/file.txt 202501010101 ; Résultat: date modifiée.
+Action: Mettre à jour la date du fichier /tmp/file.txt 202501010101 ; Résultat: La date est modifiée.

--- a/src/tests/alias_dossier_cree.shtest
+++ b/src/tests/alias_dossier_cree.shtest
@@ -1,0 +1,3 @@
+Action: Créer le dossier = /tmp/newdir ; Résultat: dossier créé.
+Action: Créer le dossier = /tmp/newdir ; Résultat: Le dossier est créé.
+Action: Créer le dossier = /tmp/newdir ; Résultat: le dossier est prêt.

--- a/src/tests/alias_logs_accessibles.shtest
+++ b/src/tests/alias_logs_accessibles.shtest
@@ -1,0 +1,2 @@
+Action: Indiquer le chemin des logs = /var/log/sys.log ; Résultat: logs accessibles.
+Action: Indiquer le chemin des logs = /var/log/sys.log ; Résultat: les logs sont accessibles.

--- a/src/validation_compiler.py
+++ b/src/validation_compiler.py
@@ -52,6 +52,24 @@ def _compile_atomic(expected: str, varname: str, last_file_var: list):
             search = "-type f"
         lines.append(f"actual=$(find {path} -maxdepth 1 {search} | wc -l)")
         lines.append(f"expected={count}")
+    elif expected.lower() == "base prête":
+        lines.append("if [ $last_ret -eq 0 ]; then actual=\"base prête\"; else actual=\"base non prête\"; fi")
+        lines.append("expected=\"base prête\"")
+    elif expected.lower() == "contenu affiché":
+        lines.append("if [ $last_ret -eq 0 ]; then actual=\"contenu affiché\"; else actual=\"contenu non affiché\"; fi")
+        lines.append("expected=\"contenu affiché\"")
+    elif expected.lower() == "dossier créé":
+        lines.append("if [ $last_ret -eq 0 ]; then actual=\"dossier créé\"; else actual=\"échec création\"; fi")
+        lines.append("expected=\"dossier créé\"")
+    elif expected.lower() == "date modifiée":
+        lines.append("if [ $last_ret -eq 0 ]; then actual=\"date modifiée\"; else actual=\"date inchangée\"; fi")
+        lines.append("expected=\"date modifiée\"")
+    elif expected.lower() == "contenu correct":
+        lines.append("if [ $last_ret -eq 0 ]; then actual=\"contenu correct\"; else actual=\"contenu incorrect\"; fi")
+        lines.append("expected=\"contenu correct\"")
+    elif expected.lower() == "logs accessibles":
+        lines.append("if [ $last_ret -eq 0 ]; then actual=\"logs accessibles\"; else actual=\"logs inaccessibles\"; fi")
+        lines.append("expected=\"logs accessibles\"")
     else:
         ret_match = re.search(r"retour\s*(\d+)", expected)
         if ret_match:


### PR DESCRIPTION
## Summary
- remove unused `parse_test_in_natural_language` helper
- drop unused `process_batch` template
- support new aliases for results such as *La base de test est prête* or *aucun message d'erreur*
- implement validation code for the new canonical forms
- add dedicated test scenarios covering each alias

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python src/generate_tests.py --batch-path ./process_batch.sh > /tmp/gen.log && tail -n 20 /tmp/gen.log`

------
https://chatgpt.com/codex/tasks/task_e_685982e64d2883319b7adac108fb7cde