### PR TITLE
Remove batch path argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,24 +59,23 @@ This generates `tests_summary.xlsx` in the current directory.
 Use `generate_tests.py` to convert `.shtest` files into executable shell scripts.
 
 ```bash
-python src/generate_tests.py --batch-path ./process_batch.sh
+python src/generate_tests.py
 ```
 
 The scripts will be created in the `output/` directory with the same name as
 their source test files.
 
-Default directories and the batch path can also be configured via
+Default directories can also be configured via
 `config.ini` at the repository root:
 
 ```ini
 [application]
 input_dir = src/tests
 output_dir = output
-batch_path = ./process_batch.sh
 ```
 
 `generate_tests.py` will read this file if present and use the values as
-defaults for `--batch-path` and where test files are located.
+defaults for where test files are located.
 
 Generated scripts use `/bin/sh` for portability.
 
@@ -89,9 +88,9 @@ export SQL_CONN="sqlplus -S myuser/mypass@mydb"
 ```
 If `SQL_CONN` is unset, `sqlplus -S user/password@db` is used.
 
-### Options
+### Notes
 
-- `--batch-path PATH` – path to the script to run for each test (default: `./process_batch.sh`)
+The path to the batch script must be provided directly in each `.shtest` file.
 
 To pass arguments to the batch script, use `argument NOM=VALEUR` in your action
 lines and chain additional pairs with `et`:

--- a/config.ini
+++ b/config.ini
@@ -1,5 +1,5 @@
+
 [application]
 input_dir = src/tests
 output_dir = output
-batch_path = ./process_batch.sh
 

--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -193,7 +193,7 @@
     <pre><code>Action: configurer le contexte ; Resultat: OK
 Action: exécuter mon_batch.sh ; Resultat: retour 0</code></pre>
     <p>Générez les scripts :</p>
-    <pre><code>python src/generate_tests.py --batch-path ./mon_batch.sh</code></pre>
+    <pre><code>python src/generate_tests.py</code></pre>
     <p>Les résultats sont disponibles dans le dossier <code>output/</code>.</p>
   </div>
 

--- a/src/generate_tests.py
+++ b/src/generate_tests.py
@@ -16,9 +16,6 @@ config.read(CONFIG_PATH)
 
 INPUT_DIR = config.get("application", "input_dir", fallback="src/tests")
 OUTPUT_DIR = config.get("application", "output_dir", fallback="output")
-DEFAULT_BATCH_PATH = config.get(
-    "application", "batch_path", fallback="./process_batch.sh"
-)
 
 
 def parse_test_file(contents: str):
@@ -36,7 +33,7 @@ def parse_test_file(contents: str):
 
 
 
-def generate_shell_script(actions_list, batch_path: str):
+def generate_shell_script(actions_list):
     """Génère un script shell à partir de la liste ordonnée d'actions.
 
     Each item in *actions_list* corresponds to a line of the original
@@ -89,7 +86,7 @@ def generate_shell_script(actions_list, batch_path: str):
 
         if actions["execution"]:
             arg_str = ' '.join([f'{k}={v}' for k, v in actions["arguments"].items()])
-            actual_path = actions.get("batch_path") or batch_path
+            actual_path = actions.get("batch_path")
             for action in actions["execution"]:
                 cmd = actual_path if not arg_str else f"{actual_path} {arg_str}"
                 lines.append(f"run_cmd \"{cmd}\"")
@@ -153,11 +150,6 @@ def generate_shell_script(actions_list, batch_path: str):
 def main():
     # Command-line interface for the generator
     parser = argparse.ArgumentParser()
-    parser.add_argument(
-        "--batch-path",
-        default=DEFAULT_BATCH_PATH,
-        help="Chemin vers le script batch",
-    )
     args = parser.parse_args()
 
     os.makedirs(OUTPUT_DIR, exist_ok=True)
@@ -165,7 +157,7 @@ def main():
         with open(txt_file, encoding="utf-8") as f:
             test_description = f.read()
         actions = parse_test_file(test_description)
-        script = generate_shell_script(actions, batch_path=args.batch_path)
+        script = generate_shell_script(actions)
         out_name = os.path.splitext(os.path.basename(txt_file))[0] + ".sh"
         out_path = os.path.join(OUTPUT_DIR, out_name)
         with open(out_path, "w", encoding="utf-8") as f:

--- a/src/parser.py
+++ b/src/parser.py
@@ -179,6 +179,8 @@ class Parser:
         # "Exécuter le script SQL = nom.sql".
         self._register(r"exécuter.*?\.sql",
                        self._handle_sql_script)
+        self._register(r"(?:exécuter|lancer|traiter)\s+(\S+\.sh)",
+                       lambda m, a: a.__setitem__("batch_path", m.group(1)))
         self._register(r"(exécuter|lancer|traiter)",
                        lambda m, a: a["execution"].append(m.string.strip()))
         self._register(r"(?:vérifier|valider)\s+que\s+(.*)",
@@ -208,8 +210,6 @@ class Parser:
                        lambda m, a: a["touch_files"].append((m.group(1), m.group(2))))
         self._register(r"(copier|d\xE9placer)\s+(?:le\s+)?(fichier|dossier)?\s*(\S+)\s+vers\s+(\S+)",
                        lambda m, a: a["copy_operations"].append((m.group(1), m.group(2) or "fichier", m.group(3), m.group(4))))
-        self._register(r"exécuter\s+(\/\S+\.sh)",
-                       lambda m, a: a.__setitem__("batch_path", m.group(1)))
         self._register(r"(?:afficher le contenu du fichier|cat le fichier|lire le fichier)\s*=?\s*(\S+)",
                        lambda m, a: a["cat_files"].append(m.group(1)))
 


### PR DESCRIPTION
## Summary
- drop `batch_path` option from config and CLI
- document that `.shtest` files must provide the batch path
- capture script path from the test files in the parser

## Testing
- `python src/generate_tests.py`
- `python -m compileall -q src`


------
https://chatgpt.com/codex/tasks/task_e_6859a14af6a8833182f37301ae610018