### PR TITLE
Add alias combination test

### DIFF
--- a/src/tests/alias_resultat_combinatoire.shtest
+++ b/src/tests/alias_resultat_combinatoire.shtest
@@ -1,0 +1,2 @@
+Action: Exécuter /opt/batch/traitement.sh ; Résultat: retour 0 et (stdout contient "OK" ou stderr contient WARNING).
+Action: Exécuter /opt/batch/traitement.sh ; Résultat: Le script retourne un code 0 et (La sortie standard contient "OK" ou La sortie d'erreur contient WARNING).

--- a/src/tests/bdd_example.shtest
+++ b/src/tests/bdd_example.shtest
@@ -1,0 +1,7 @@
+Step: preparation
+Action: Définir la variable SQL_CONN = sqlplus -S user/password@db ; Résultat: identifiants configurés.
+Action: Exécuter le script SQL init_bdd.sql ; Résultat: La base de test est prête.
+Step: execution
+Action: Exécuter /opt/batch/migration.sh ; Résultat: retour 0.
+Step: verification
+Action: Exécuter le script SQL verification.sql ; Résultat: base prête.


### PR DESCRIPTION
## Summary
- adjust `bdd_example.shtest` to use three steps
- add `alias_resultat_combinatoire.shtest` demonstrating aliases inside logical combinations

## Testing
- `python src/generate_tests.py`


------
https://chatgpt.com/codex/tasks/task_e_6859a52d575c833199da5428891a7b4d