### PR TITLE
Add directory purge command

### DIFF
--- a/docs/documentation.html
+++ b/docs/documentation.html
@@ -98,6 +98,7 @@
       <tr><td><code>mettre à jour la date du fichier CHEMIN TIMESTAMP</code></td><td>-</td><td>Met à jour la date du fichier</td></tr>
       <tr><td><code>copier le fichier SRC vers DEST</code></td><td>-</td><td>Copie un fichier</td></tr>
       <tr><td><code>copier le dossier SRC vers DEST</code></td><td>-</td><td>Copie un dossier</td></tr>
+      <tr><td><code>purger le dossier CHEMIN</code></td><td><code>vider le r&eacute;pertoire CHEMIN</code></td><td>Supprime tout le contenu du dossier</td></tr>
       <tr><td><code>afficher le contenu du fichier=CHEMIN</code></td><td><code>cat le fichier</code></td><td>Affiche le contenu d’un fichier</td></tr>
     </table>
 

--- a/src/generate_tests.py
+++ b/src/generate_tests.py
@@ -119,6 +119,11 @@ def generate_shell_script(actions_list):
                         cmd = TEMPLATES["copy_file"].substitute(src=src, dest=dest)
                 lines.append(f"run_cmd \"{cmd}\"")
 
+        if actions.get("purge_dirs"):
+            for path in actions["purge_dirs"]:
+                cmd = TEMPLATES["purge_dir"].substitute(path=path)
+                lines.append(f"run_cmd \"{cmd}\"")
+
         if actions.get("touch_files"):
             for entry in actions["touch_files"]:
                 path, ts = entry if isinstance(entry, tuple) else (entry, None)

--- a/src/parser.py
+++ b/src/parser.py
@@ -222,6 +222,8 @@ class Parser:
                        lambda m, a: a["copy_operations"].append((m.group(1), m.group(2) or "fichier", m.group(3), m.group(4))))
         self._register(r"(?:afficher le contenu du fichier|cat le fichier|lire le fichier)\s*=?\s*(\S+)",
                        lambda m, a: a["cat_files"].append(m.group(1)))
+        self._register(r"(?:vider|purger)\s+le\s+(?:r[eé]pertoire|dossier)\s*=?\s*(\S+)",
+                       lambda m, a: a["purge_dirs"].append(m.group(1)))
 
     def _handle_arguments(self, match: re.Match, actions: Dict[str, List]) -> None:
         """Extract all key=value pairs from an argument expression."""
@@ -274,6 +276,7 @@ class Parser:
             "copy_operations": [],
             "cat_files": [],
             "touch_files": [],
+            "purge_dirs": [],
             "steps": [],
             "batch_path": None,
         }

--- a/src/templates.py
+++ b/src/templates.py
@@ -13,5 +13,6 @@ TEMPLATES = {
     "copy_file": Template("cp ${src} ${dest}"),
     "copy_dir": Template("cp -r ${src} ${dest}"),
     "move": Template("mv ${src} ${dest}"),
+    "purge_dir": Template("rm -rf ${path}/* && mkdir -p ${path}"),
 }
 

--- a/src/tests/alias_action_purge.shtest
+++ b/src/tests/alias_action_purge.shtest
@@ -1,0 +1,1 @@
+Action: Vider le répertoire /tmp/cache ; Résultat: le dossier est prêt.


### PR DESCRIPTION
## Summary
- support purging directories via new `purge_dir` template
- parse `Vider le répertoire`/`Purger le dossier`
- generate `run_cmd` for directory purge
- document purge syntax
- add example test file

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `python src/generate_tests.py > /tmp/generate.log`

------
https://chatgpt.com/codex/tasks/task_e_685c0b9dd22883318a2a8fc1c1755e2d