### PR TITLE
Add syntax verification tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ The HTML documentation in [`docs/`](docs/index.html) is generated from the [iDoc
 ## Quick Start
 1. Create your `.shtest` scenarios inside `src/tests`.
 2. Run `python src/generate_tests.py` to produce shell scripts in `output/`.
-3. Optionally run `python src/export_to_excel.py` to create an Excel summary.
+3. Optionally run `python src/verify_syntax.py` to validate the scenarios.
+4. Optionally run `python src/export_to_excel.py` to create an Excel summary.
 
 Default directories can be adjusted in `config.ini`.
 
@@ -21,6 +22,16 @@ python src/generate_tests.py
 ```
 
 Paths can be customised via `config.ini`.
+
+### `verify_syntax.py`
+Checks `.shtest` files for syntax errors using the built-in parser.
+
+```bash
+python src/verify_syntax.py src/tests
+```
+
+Provide directories or files as arguments. The script exits with a non-zero
+status if issues are found.
 
 ### `export_to_excel.py`
 Creates an Excel workbook summarising each scenario.

--- a/docs/README.md
+++ b/docs/README.md
@@ -8,13 +8,15 @@ les convertir en scripts shell exécutables.
 ## Démarrage rapide
 1. Créez vos scénarios dans `src/tests` au format `.shtest`.
 2. Exécutez `python src/generate_tests.py` pour produire des scripts dans `output/`.
-3. (Optionnel) Lancez `python src/export_to_excel.py` pour obtenir un
+3. (Optionnel) Lancez `python src/verify_syntax.py` pour vérifier la syntaxe des scénarios.
+4. (Optionnel) Lancez `python src/export_to_excel.py` pour obtenir un
    résumé au format Excel.
 
 Les chemins par défaut peuvent être ajustés dans `config.ini`.
 
 ## Outils
 - **generate_tests.py** : génère les scripts shell à partir des fichiers `.shtest`.
+- **verify_syntax.py** : vérifie la syntaxe des scénarios avant exécution.
 - **export_to_excel.py** : crée un tableau récapitulatif des scénarios.
 
 Pour plus d'informations, consultez les pages HTML de ce dossier.

--- a/src/verify_syntax.py
+++ b/src/verify_syntax.py
@@ -1,0 +1,77 @@
+import argparse
+import os
+import configparser
+from typing import List
+
+from parser.parser import Parser
+from parser.shunting_yard import parse_validation_expression
+
+CONFIG_PATH = os.path.join(os.path.dirname(__file__), "..", "config.ini")
+config = configparser.ConfigParser()
+config.read(CONFIG_PATH)
+
+DEFAULT_INPUT_DIR = config.get("application", "input_dir", fallback="src/tests")
+
+
+def _is_actions_empty(actions: dict) -> bool:
+    for key, value in actions.items():
+        if key == "batch_path":
+            if value:
+                return False
+        elif value:
+            return False
+    return True
+
+
+def check_file(path: str, parser: Parser) -> List[str]:
+    errors: List[str] = []
+    with open(path, encoding="utf-8") as f:
+        for lineno, line in enumerate(f, start=1):
+            text = line.strip()
+            if not text or text.startswith("#"):
+                continue
+            actions = parser.parse(text)
+            if _is_actions_empty(actions):
+                errors.append(f"{path}:{lineno}: ligne non reconnue -> {text}")
+                continue
+            for expr in actions.get("validation", []):
+                try:
+                    parse_validation_expression(expr)
+                except Exception as exc:  # pragma: no cover - unexpected failures
+                    errors.append(
+                        f"{path}:{lineno}: expression invalide -> {expr} ({exc})"
+                    )
+    return errors
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "paths",
+        nargs="*",
+        default=[DEFAULT_INPUT_DIR],
+        help="Files or directories to check",
+    )
+    args = parser.parse_args()
+
+    p = Parser()
+    all_errors: List[str] = []
+
+    for path in args.paths:
+        if os.path.isdir(path):
+            for name in os.listdir(path):
+                if name.endswith(".shtest"):
+                    full = os.path.join(path, name)
+                    all_errors.extend(check_file(full, p))
+        else:
+            all_errors.extend(check_file(path, p))
+
+    if all_errors:
+        print("\n".join(all_errors))
+        raise SystemExit(1)
+
+    print("Syntax OK")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add `verify_syntax.py` to validate `.shtest` files using the parser
- document the new tool in README and docs

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ff8ae8d9c83319abc07848baedb98