### PR TITLE
Add stricter syntax checks with line numbers

### DIFF
--- a/src/compiler/tests/test_compiler.py
+++ b/src/compiler/tests/test_compiler.py
@@ -1,4 +1,9 @@
+import os
+import sys
 import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
+
 from compiler.compiler import compile_validation
 
 class TestValidationCompiler(unittest.TestCase):

--- a/src/generate_tests.py
+++ b/src/generate_tests.py
@@ -1,6 +1,7 @@
 """Utilities to transform ``.shtest`` files into executable shell scripts."""
 
 from parser.parser import Parser
+from lexer import lex
 from templates import TEMPLATES
 from compiler.compiler import compile_validation
 import argparse
@@ -19,14 +20,19 @@ OUTPUT_DIR = config.get("application", "output_dir", fallback="output")
 
 
 def parse_test_file(contents: str):
-    """Parse line by line and preserve ordering of actions/results."""
+    """Parse a ``.shtest`` file and preserve the line ordering."""
 
     parser = Parser()
     parsed_lines = []
-    for line in contents.splitlines():
-        # ``Parser.parse`` only deals with a single line. We keep the list
-        # of results in order so that the generated script mirrors the
-        # original description.
+    for token in lex(contents):
+        if token.kind == "STEP":
+            line = f"Étape: {token.value}"
+        elif token.kind == "ACTION_RESULT":
+            line = f"Action: {token.value} ; Résultat: {token.result}"
+        elif token.kind == "ACTION_ONLY":
+            line = f"Action: {token.value}"
+        else:
+            line = token.value
         parsed_lines.append(parser.parse(line))
     return parsed_lines
 

--- a/src/lexer.py
+++ b/src/lexer.py
@@ -1,0 +1,48 @@
+import re
+from dataclasses import dataclass
+from typing import Iterator, Optional
+
+@dataclass
+class Token:
+    kind: str
+    value: str
+    lineno: int
+    result: Optional[str] = None
+    original: Optional[str] = None
+
+_STEP_RE = re.compile(r"^(?:Étape|Etape|Step)\s*:\s*(.*)", re.IGNORECASE)
+_ACTION_RESULT_RE = re.compile(
+    r"^Action\s*:\s*(.*?)\s*(?:R[ée]sultat|Resultat)\s*:?\s*(.*)", re.IGNORECASE
+)
+_ACTION_ONLY_RE = re.compile(r"^Action\s*:\s*(.*)", re.IGNORECASE)
+
+def lex(text: str) -> Iterator[Token]:
+    """Tokenize the contents of a ``.shtest`` file."""
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        stripped = line.strip()
+        if not stripped:
+            continue
+        m = _STEP_RE.match(stripped)
+        if m:
+            yield Token("STEP", m.group(1).strip(), lineno, original=line)
+            continue
+        m = _ACTION_RESULT_RE.match(stripped)
+        if m:
+            yield Token(
+                "ACTION_RESULT",
+                m.group(1).strip(),
+                lineno,
+                result=m.group(2).strip(),
+                original=line,
+            )
+            continue
+        m = _ACTION_ONLY_RE.match(stripped)
+        if m:
+            yield Token("ACTION_ONLY", m.group(1).strip(), lineno, original=line)
+            continue
+        yield Token("TEXT", stripped, lineno, original=line)
+
+def lex_file(path: str) -> Iterator[Token]:
+    """Read *path* and yield :class:`Token` objects."""
+    with open(path, encoding="utf-8") as f:
+        yield from lex(f.read())

--- a/src/parser/test_parser.py
+++ b/src/parser/test_parser.py
@@ -1,5 +1,10 @@
 
+import os
+import sys
 import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
+
 from parser.parser import Parser
 
 class TestParser(unittest.TestCase):

--- a/src/verify_syntax.py
+++ b/src/verify_syntax.py
@@ -5,6 +5,7 @@ from typing import List
 
 from parser.parser import Parser
 from parser.shunting_yard import parse_validation_expression
+from lexer import lex_file
 
 CONFIG_PATH = os.path.join(os.path.dirname(__file__), "..", "config.ini")
 config = configparser.ConfigParser()
@@ -24,23 +25,59 @@ def _is_actions_empty(actions: dict) -> bool:
 
 
 def check_file(path: str, parser: Parser) -> List[str]:
+    """Return a list of syntax errors found in *path*."""
     errors: List[str] = []
-    with open(path, encoding="utf-8") as f:
-        for lineno, line in enumerate(f, start=1):
-            text = line.strip()
-            if not text or text.startswith("#"):
-                continue
-            actions = parser.parse(text)
+    current_step_lineno: int | None = None
+    current_step_name: str = ""
+    step_has_action = False
+
+    for token in lex_file(path):
+        if token.kind == "STEP":
+            # Report an empty step before starting a new one
+            if current_step_lineno is not None and not step_has_action:
+                errors.append(
+                    f"{path}:{current_step_lineno}: \u00e9tape sans action -> {current_step_name}"
+                )
+            current_step_lineno = token.lineno
+            current_step_name = token.value
+            step_has_action = False
+            line = f"\u00c9tape: {token.value}"
+            actions = parser.parse(line)
             if _is_actions_empty(actions):
-                errors.append(f"{path}:{lineno}: ligne non reconnue -> {text}")
-                continue
+                errors.append(f"{path}:{token.lineno}: ligne non reconnue -> {line}")
+            continue
+
+        if token.kind in ("ACTION_RESULT", "ACTION_ONLY"):
+            if current_step_lineno is None:
+                errors.append(
+                    f"{path}:{token.lineno}: action sans \u00e9tape -> {token.original or token.value}"
+                )
+            line = (
+                f"Action: {token.value} ; R\u00e9sultat: {token.result}"
+                if token.kind == "ACTION_RESULT"
+                else f"Action: {token.value}"
+            )
+            actions = parser.parse(line)
+            if _is_actions_empty(actions):
+                errors.append(f"{path}:{token.lineno}: ligne non reconnue -> {line}")
             for expr in actions.get("validation", []):
                 try:
                     parse_validation_expression(expr)
                 except Exception as exc:  # pragma: no cover - unexpected failures
                     errors.append(
-                        f"{path}:{lineno}: expression invalide -> {expr} ({exc})"
+                        f"{path}:{token.lineno}: expression invalide -> {expr} ({exc})"
                     )
+            step_has_action = True
+            continue
+
+        # Any other token is unrecognised text
+        errors.append(f"{path}:{token.lineno}: ligne non reconnue -> {token.value}")
+
+    if current_step_lineno is not None and not step_has_action:
+        errors.append(
+            f"{path}:{current_step_lineno}: \u00e9tape sans action -> {current_step_name}"
+        )
+
     return errors
 
 

--- a/tests/test_verify_syntax.py
+++ b/tests/test_verify_syntax.py
@@ -1,0 +1,41 @@
+import os
+import sys
+import tempfile
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+import verify_syntax
+from parser.parser import Parser
+
+
+class TestVerifySyntax(unittest.TestCase):
+    def setUp(self):
+        self.parser = Parser()
+
+    def _write_temp(self, content: str) -> str:
+        tmp = tempfile.NamedTemporaryFile('w', delete=False, suffix='.shtest')
+        tmp.write(content)
+        tmp.close()
+        return tmp.name
+
+    def test_invalid_line_number(self):
+        path = self._write_temp("Étape: S\nAction: Définir la variable X = 1\nblabla\n")
+        try:
+            errors = verify_syntax.check_file(path, self.parser)
+        finally:
+            os.unlink(path)
+        self.assertEqual(len(errors), 1)
+        self.assertIn(':3:', errors[0])
+
+    def test_empty_step_error(self):
+        path = self._write_temp("Étape: A\nÉtape: B\nAction: echo\n")
+        try:
+            errors = verify_syntax.check_file(path, self.parser)
+        finally:
+            os.unlink(path)
+        self.assertTrue(any(':1:' in e and 'étape sans action' in e for e in errors))
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- improve `check_file` in `verify_syntax.py` to detect empty steps and actions outside of steps
- emit error messages with line numbers
- add unit tests for new verification rules

## Testing
- `pytest -q`

