### PR TITLE
Add nested tokenization to lexer

### DIFF
--- a/src/lexer.py
+++ b/src/lexer.py
@@ -16,8 +16,12 @@ _ACTION_RESULT_RE = re.compile(
 )
 _ACTION_ONLY_RE = re.compile(r"^Action\s*:\s*(.*)", re.IGNORECASE)
 
-def lex(text: str) -> Iterator[Token]:
-    """Tokenize the contents of a ``.shtest`` file."""
+def lex(text: str, nested: bool = False) -> Iterator[Token]:
+    """Tokenize the contents of a ``.shtest`` file.
+
+    If *nested* is True, additional tokens are emitted for the
+    expressions inside actions and results.
+    """
     for lineno, line in enumerate(text.splitlines(), start=1):
         stripped = line.strip()
         if not stripped:
@@ -28,21 +32,30 @@ def lex(text: str) -> Iterator[Token]:
             continue
         m = _ACTION_RESULT_RE.match(stripped)
         if m:
+            action = m.group(1).strip()
+            result = m.group(2).strip()
             yield Token(
                 "ACTION_RESULT",
-                m.group(1).strip(),
+                action,
                 lineno,
-                result=m.group(2).strip(),
+                result=result,
                 original=line,
             )
+            if nested:
+                yield Token("ACTION_EXPR", action, lineno, original=line)
+                if result:
+                    yield Token("RESULT_EXPR", result, lineno, original=line)
             continue
         m = _ACTION_ONLY_RE.match(stripped)
         if m:
-            yield Token("ACTION_ONLY", m.group(1).strip(), lineno, original=line)
+            action = m.group(1).strip()
+            yield Token("ACTION_ONLY", action, lineno, original=line)
+            if nested:
+                yield Token("ACTION_EXPR", action, lineno, original=line)
             continue
         yield Token("TEXT", stripped, lineno, original=line)
 
-def lex_file(path: str) -> Iterator[Token]:
+def lex_file(path: str, nested: bool = False) -> Iterator[Token]:
     """Read *path* and yield :class:`Token` objects."""
     with open(path, encoding="utf-8") as f:
-        yield from lex(f.read())
+        yield from lex(f.read(), nested=nested)

--- a/tests/test_lexer.py
+++ b/tests/test_lexer.py
@@ -1,0 +1,29 @@
+import os
+import sys
+import unittest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+
+from lexer import lex
+
+class TestLexerNested(unittest.TestCase):
+    def test_nested_action_result(self):
+        text = "Action: Exécuter script.sh ; Résultat: base prête."
+        tokens = list(lex(text, nested=True))
+        self.assertEqual(tokens[0].kind, "ACTION_RESULT")
+        self.assertEqual(tokens[0].value, "Exécuter script.sh ;")
+        self.assertEqual(tokens[0].result, "base prête.")
+        kinds = [t.kind for t in tokens]
+        self.assertIn("ACTION_EXPR", kinds)
+        self.assertIn("RESULT_EXPR", kinds)
+
+    def test_nested_action_only(self):
+        text = "Action: echo hello"
+        tokens = list(lex(text, nested=True))
+        self.assertEqual(tokens[0].kind, "ACTION_ONLY")
+        self.assertEqual(tokens[0].value, "echo hello")
+        kinds = [t.kind for t in tokens]
+        self.assertIn("ACTION_EXPR", kinds)
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary
- extend lexer to optionally emit tokens for inner expressions
- provide tests covering nested tokenization

## Testing
- `pytest -q`

