### PR TITLE
Organize unit tests

### DIFF
--- a/tests/unit/test_compiler.py
+++ b/tests/unit/test_compiler.py
@@ -2,7 +2,7 @@ import os
 import sys
 import unittest
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
 
 from compiler.compiler import compile_validation
 

--- a/tests/unit/test_generate_tests.py
+++ b/tests/unit/test_generate_tests.py
@@ -2,7 +2,7 @@ import os
 import sys
 import unittest
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
 
 from generate_tests import parse_test_file, generate_shell_script
 
@@ -27,6 +27,18 @@ class TestGenerateShellScript(unittest.TestCase):
         actions = parse_test_file(content)
         script = generate_shell_script(actions)
         self.assertNotIn('run_cmd "None"', script)
+
+    def test_step_and_sql_validation(self):
+        content = (
+            "\u00c9tape: Pr\u00e9paration\n"
+            "Action: Ex\u00e9cuter le script SQL init.sql ; R\u00e9sultat: base pr\u00eate."
+        )
+        actions = parse_test_file(content)
+        script = generate_shell_script(actions)
+        lines = script.splitlines()
+        self.assertIn("# ---- Pr\u00e9paration ----", lines)
+        self.assertTrue(any("init.sql" in line for line in lines))
+        self.assertTrue(any("log_diff" in line for line in lines))
 
 
 if __name__ == "__main__":

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -3,7 +3,7 @@ import os
 import sys
 import unittest
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
 
 from parser.parser import Parser
 

--- a/tests/unit/test_verify_syntax.py
+++ b/tests/unit/test_verify_syntax.py
@@ -3,7 +3,7 @@ import sys
 import tempfile
 import unittest
 
-sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', 'src'))
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), '..', '..', 'src'))
 
 import verify_syntax
 from parser.parser import Parser
@@ -35,6 +35,14 @@ class TestVerifySyntax(unittest.TestCase):
         finally:
             os.unlink(path)
         self.assertTrue(any(':1:' in e and 'étape sans action' in e for e in errors))
+
+    def test_action_without_step(self):
+        path = self._write_temp("Action: echo 1\n")
+        try:
+            errors = verify_syntax.check_file(path, self.parser)
+        finally:
+            os.unlink(path)
+        self.assertTrue(any('action sans étape' in e for e in errors))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
## Summary
- move all unit tests into `tests/unit`
- add a test covering SQL execution and step comments in generated shell scripts
- add test ensuring actions without steps are reported as errors

## Testing
- `pytest -q`

