### PR TITLE
Fix diff and SQL checks

### DIFF
--- a/demo_env/bdd_example.sh
+++ b/demo_env/bdd_example.sh
@@ -31,7 +31,10 @@ verdict="KO"
 if [ ${cond1} -eq 1 ]; then verdict="OK"; fi
 expected="OK"
 log_diff "$expected" "$verdict"
-run_cmd "sqlplus -S ${SQL_CONN:-user/password@db} @init_bdd.sql"
+run_cmd "sqlplus -S ${SQL_CONN:-user/password@db} <<'EOF'
+WHENEVER SQLERROR EXIT 1;
+@init_bdd.sql
+EOF"
 # Attendu : La base est prête pour le test
 actual="non vérifié"
 expected="La base est prête pour le test"
@@ -53,7 +56,10 @@ if [ ${cond3} -eq 1 ]; then verdict="OK"; fi
 expected="OK"
 log_diff "$expected" "$verdict"
 # ---- verification ----
-run_cmd "sqlplus -S ${SQL_CONN:-user/password@db} @verification.sql"
+run_cmd "sqlplus -S ${SQL_CONN:-user/password@db} <<'EOF'
+WHENEVER SQLERROR EXIT 1;
+@verification.sql
+EOF"
 # Attendu : retour 0
 if [ $last_ret -eq 0 ]; then actual="retour 0"; else actual="retour $last_ret"; fi
 expected="retour 0"

--- a/demo_env/demo_long_test.sh
+++ b/demo_env/demo_long_test.sh
@@ -107,7 +107,10 @@ if [ ${cond11} -eq 1 ]; then verdict="OK"; fi
 expected="OK"
 log_diff "$expected" "$verdict"
 # ---- Step 5 - Vérifier la table en base ----
-run_cmd "sqlplus -S ${SQL_CONN:-user/password@db} @verification.sql"
+run_cmd "sqlplus -S ${SQL_CONN:-user/password@db} <<'EOF'
+WHENEVER SQLERROR EXIT 1;
+@verification.sql
+EOF"
 # Attendu : retour 0
 if [ $last_ret -eq 0 ]; then actual="retour 0"; else actual="retour $last_ret"; fi
 expected="retour 0"
@@ -117,8 +120,8 @@ verdict="KO"
 if [ ${cond12} -eq 1 ]; then verdict="OK"; fi
 expected="OK"
 log_diff "$expected" "$verdict"
-# Attendu : Les fichiers sont identiques
-actual="non vérifié"
+# Attendu : fichier_identique ./output.txt ./output_attendu.txt
+if diff -q ./output.txt ./output_attendu.txt >/dev/null; then actual="Les fichiers sont identiques"; else actual="Les fichiers sont différents"; fi
 expected="Les fichiers sont identiques"
 log_diff "$expected" "$actual"
 if [ "$expected" = "$actual" ]; then cond13=1; else cond13=0; fi

--- a/src/compiler/matchers/file_matchers.py
+++ b/src/compiler/matchers/file_matchers.py
@@ -1,10 +1,20 @@
 import re
 
 def match(expected, last_file_var):
-    for fn in [_match_file_exists, _match_file_contains_exact, _match_file_contains, _match_dir_file_count]:
+    for fn in [_match_files_identical, _match_file_exists, _match_file_contains_exact, _match_file_contains, _match_dir_file_count]:
         result = fn(expected, last_file_var)
         if result:
             return result
+    return None
+
+def _match_files_identical(expected, _):
+    m = re.search(r"fichier_identique\s+(\S+)\s+(\S+)", expected, re.IGNORECASE)
+    if m:
+        src, dest = m.groups()
+        return [
+            f"if diff -q {src} {dest} >/dev/null; then actual=\"Les fichiers sont identiques\"; else actual=\"Les fichiers sont différents\"; fi",
+            "expected=\"Les fichiers sont identiques\"",
+        ]
     return None
 
 def _match_file_exists(expected, last_file_var):

--- a/src/parser/alias_resolver.py
+++ b/src/parser/alias_resolver.py
@@ -26,6 +26,7 @@ class AliasResolver:
             (re.compile(r"le dossier\s+est\s+cr[eé]{1,2}e?", re.I), lambda m: ["dossier créé"]),
             (re.compile(r"le script s'?ex[ée]cute\s+avec\s+succ[eè]s", re.I), lambda m: ["retour 0"]),
             (re.compile(r"le fichier\s+(\S+)\s+est identique(?:\s+[àa])?\s*(\S+)", re.I), lambda m: [f"fichier_identique {m[1]} {m[2]}"]),
+            (re.compile(r"les?\s+fichiers\s+sont\s+identiques", re.I), lambda m: ["les fichiers sont identiques"]),
             (re.compile(r"fichier\s+cr[eé]{1,2}e?", re.I), lambda m: ["fichier cree"]),
             (re.compile(r"la base(?: de test)?\s+est\s+pr[êe]te", re.I), lambda m: ["base prête"]),
             (re.compile(r"le contenu\s+est\s+(?:affich[ée]|correct|lisible)", re.I), lambda m: ["contenu affiché" if "lisible" in m[0] or "affich" in m[0] else "contenu correct"]),

--- a/src/templates.py
+++ b/src/templates.py
@@ -4,7 +4,7 @@ TEMPLATES = {
     "grep_log": Template("grep 'ERROR' ${path}"),
     # The SQL connection can be overridden via the SQL_CONN environment variable.
     # The default connection uses sqlplus with hardcoded credentials.
-    "execute_sql": Template("sqlplus -S ${conn} @${script}"),
+    "execute_sql": Template("sqlplus -S ${conn} <<'EOF'\nWHENEVER SQLERROR EXIT 1;\n@${script}\nEOF"),
     "create_dir": Template("mkdir -p ${path} && chmod ${mode} ${path}"),
     "create_file": Template("touch ${path} && chmod ${mode} ${path}"),
     "update_file": Template("touch ${path}"),

--- a/tests/unit/test_generate_tests.py
+++ b/tests/unit/test_generate_tests.py
@@ -31,7 +31,7 @@ class TestGenerateShellScript(unittest.TestCase):
         actions = parse_test_file(content)
         script = generate_shell_script(actions)
         self.assertIn(
-            'run_cmd "sqlplus -S ${SQL_CONN:-user/password@db} @init_bdd.sql"',
+            "sqlplus -S ${SQL_CONN:-user/password@db} <<'EOF'",
             script,
         )
 


### PR DESCRIPTION
## Summary
- ensure SQL scripts exit on error
- allow comparing files in scenario parser
- compile file diff validations in shell scripts
- adjust unit test for sqlplus template
- regenerate demo scripts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6860235b32988331a41c4c83cefd0cba