### PR TITLE
Add SQL driver configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The existing HTML pages generated from the [iDocs](https://github.com/harnishdes
 3. Optionally run `python src/verify_syntax.py` to validate the scenarios.
 4. Optionally run `python src/export_to_excel.py` to create an Excel summary.
 
-Default directories can be adjusted in `config.ini`.
+Default directories and the `sql_driver` used for SQL scripts can be adjusted in `config.ini`.
 
 ## Command Reference
 

--- a/config.ini
+++ b/config.ini
@@ -2,4 +2,5 @@
 [application]
 input_dir = demo_env
 output_dir = demo_env
+sql_driver = oracle
 

--- a/docs/docs/configuration.md
+++ b/docs/docs/configuration.md
@@ -6,7 +6,8 @@ Le fichier `config.ini` situé à la racine du projet permet de définir les che
 [application]
 input_dir = demo_env
 output_dir = demo_env
+sql_driver = oracle
 ```
 
-Vous pouvez modifier ces valeurs pour adapter l'outil à votre environnement. Chaque script dispose également d'options en ligne de commande pour surcharger ces paramètres.
+Vous pouvez modifier ces valeurs pour adapter l'outil à votre environnement. La clé `sql_driver` permet de choisir quel moteur SQL utiliser parmi `mysql`, `oracle`, `postgres` ou `redis`. Chaque script dispose également d'options en ligne de commande pour surcharger ces paramètres.
 

--- a/src/compiler/matchers/drivers/__init__.py
+++ b/src/compiler/matchers/drivers/__init__.py
@@ -14,7 +14,15 @@ COMMANDS = {
 }
 
 
-def get_sql_command(script: str, conn: str) -> str:
-    driver = os.environ.get("SQL_DRIVER", "oracle").lower()
+def get_sql_command(script: str, conn: str, driver: str | None = None) -> str:
+    """Return the shell command to execute *script* with the given *driver*.
+
+    If *driver* is ``None`` the ``SQL_DRIVER`` environment variable is used,
+    falling back to ``oracle``.
+    """
+
+    if driver is None:
+        driver = os.environ.get("SQL_DRIVER", "oracle")
+    driver = driver.lower()
     template = COMMANDS.get(driver, ORACLE_TEMPLATE)
     return template.substitute(script=script, conn=conn)

--- a/src/compiler/matchers/drivers/__init__.py
+++ b/src/compiler/matchers/drivers/__init__.py
@@ -1,0 +1,20 @@
+import os
+from string import Template
+
+from .mysql import MYSQL_TEMPLATE
+from .oracle import ORACLE_TEMPLATE
+from .postgres import POSTGRES_TEMPLATE
+from .redis import REDIS_TEMPLATE
+
+COMMANDS = {
+    "mysql": MYSQL_TEMPLATE,
+    "oracle": ORACLE_TEMPLATE,
+    "postgres": POSTGRES_TEMPLATE,
+    "redis": REDIS_TEMPLATE,
+}
+
+
+def get_sql_command(script: str, conn: str) -> str:
+    driver = os.environ.get("SQL_DRIVER", "oracle").lower()
+    template = COMMANDS.get(driver, ORACLE_TEMPLATE)
+    return template.substitute(script=script, conn=conn)

--- a/src/compiler/matchers/drivers/mysql.py
+++ b/src/compiler/matchers/drivers/mysql.py
@@ -1,0 +1,3 @@
+from string import Template
+
+MYSQL_TEMPLATE = Template("mysql $conn < $script")

--- a/src/compiler/matchers/drivers/oracle.py
+++ b/src/compiler/matchers/drivers/oracle.py
@@ -1,0 +1,3 @@
+from string import Template
+
+ORACLE_TEMPLATE = Template("sqlplus -S $conn <<'EOF'\nWHENEVER SQLERROR EXIT 1;\n@$script\nEOF")

--- a/src/compiler/matchers/drivers/postgres.py
+++ b/src/compiler/matchers/drivers/postgres.py
@@ -1,0 +1,3 @@
+from string import Template
+
+POSTGRES_TEMPLATE = Template("psql $conn -f $script")

--- a/src/compiler/matchers/drivers/redis.py
+++ b/src/compiler/matchers/drivers/redis.py
@@ -1,0 +1,3 @@
+from string import Template
+
+REDIS_TEMPLATE = Template("redis-cli $conn < $script")

--- a/src/generate_tests.py
+++ b/src/generate_tests.py
@@ -43,6 +43,7 @@ def generate_shell_script(actions_list):
     ]
 
     counter = [0]
+    current_driver = os.environ.get("SQL_DRIVER", "oracle")
     for actions in actions_list:
         if actions.get("steps"):
             lines.append(f"# ---- {actions['steps'][0]} ----")
@@ -50,13 +51,15 @@ def generate_shell_script(actions_list):
         if actions.get("arguments"):
             for key, value in actions["arguments"].items():
                 lines.append(f"export {key}=\"{value}\"")
+                if key == "SQL_DRIVER":
+                    current_driver = value
         if actions.get("initialization"):
             lines.append("# Initialisation")
             for action in actions["initialization"]:
                 scripts = re.findall(r"\S+\.sql", action, re.IGNORECASE)
                 if scripts:
                     for script in scripts:
-                        cmd = get_sql_command(script=script, conn='${SQL_CONN:-user/password@db}')
+                        cmd = get_sql_command(script=script, conn='${SQL_CONN:-user/password@db}', driver=current_driver)
                         lines.append(f"run_cmd \"{cmd}\"")
                 else:
                     lines.append(f"run_cmd \"echo '{action}'\"")
@@ -67,7 +70,7 @@ def generate_shell_script(actions_list):
                 scripts = re.findall(r"\S+\.sql", action, re.IGNORECASE)
                 if scripts:
                     for script in scripts:
-                        cmd = get_sql_command(script=script, conn='${SQL_CONN:-user/password@db}')
+                        cmd = get_sql_command(script=script, conn='${SQL_CONN:-user/password@db}', driver=current_driver)
                         lines.append(f"run_cmd \"{cmd}\"")
                     continue
                 if actual_path is None:

--- a/src/generate_tests.py
+++ b/src/generate_tests.py
@@ -1,6 +1,7 @@
 from parser.parser import Parser
 from lexer import lex
 from templates import TEMPLATES
+from compiler.matchers.drivers import get_sql_command
 from compiler.compiler import compile_validation
 import os
 from glob import glob
@@ -55,7 +56,7 @@ def generate_shell_script(actions_list):
                 scripts = re.findall(r"\S+\.sql", action, re.IGNORECASE)
                 if scripts:
                     for script in scripts:
-                        cmd = TEMPLATES['execute_sql'].substitute(script=script, conn='${SQL_CONN:-user/password@db}')
+                        cmd = get_sql_command(script=script, conn='${SQL_CONN:-user/password@db}')
                         lines.append(f"run_cmd \"{cmd}\"")
                 else:
                     lines.append(f"run_cmd \"echo '{action}'\"")
@@ -66,7 +67,7 @@ def generate_shell_script(actions_list):
                 scripts = re.findall(r"\S+\.sql", action, re.IGNORECASE)
                 if scripts:
                     for script in scripts:
-                        cmd = TEMPLATES['execute_sql'].substitute(script=script, conn='${SQL_CONN:-user/password@db}')
+                        cmd = get_sql_command(script=script, conn='${SQL_CONN:-user/password@db}')
                         lines.append(f"run_cmd \"{cmd}\"")
                     continue
                 if actual_path is None:

--- a/src/run_all.py
+++ b/src/run_all.py
@@ -15,7 +15,8 @@ def read_config():
     config.read(CONFIG_PATH)
     input_dir = config.get("application", "input_dir", fallback="tests")
     output_dir = config.get("application", "output_dir", fallback="output")
-    return input_dir, output_dir
+    sql_driver = config.get("application", "sql_driver", fallback="oracle")
+    return input_dir, output_dir, sql_driver
 
 def run_syntax_check(input_dir: str):
     print("[1/3] Vérification de la syntaxe...")
@@ -47,9 +48,11 @@ def main():
     parser.add_argument("--no-excel", action="store_true", help="Ne pas générer le fichier Excel")
     args = parser.parse_args()
 
-    config_input, config_output = read_config()
+    config_input, config_output, config_driver = read_config()
     input_dir = args.input or config_input
     output_dir = args.output or config_output
+    if "SQL_DRIVER" not in os.environ:
+        os.environ["SQL_DRIVER"] = config_driver
     excel_file = args.excel or os.path.join(output_dir, "tests_summary.xlsx")
 
     run_syntax_check(input_dir)

--- a/tests/unit/test_generate_tests.py
+++ b/tests/unit/test_generate_tests.py
@@ -57,6 +57,18 @@ class TestGenerateShellScript(unittest.TestCase):
         self.assertIn('cond1', script)
         self.assertIn('cond2', script)
 
+    def test_sql_driver_override(self):
+        content = (
+            "Action: Définir la variable SQL_DRIVER = mysql ;\n"
+            "Action: Exécuter le script SQL init.sql ;"
+        )
+        actions = parse_test_file(content)
+        script = generate_shell_script(actions)
+        self.assertIn(
+            "mysql ${SQL_CONN:-user/password@db} < init.sql",
+            script,
+        )
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary
- add configurable `sql_driver` in `config.ini`
- create driver templates for mysql, oracle, postgres and redis
- generate SQL commands based on `SQL_DRIVER`
- propagate SQL driver from configuration in `run_all.py`
- document `sql_driver` option and mention it in README

## Testing
- `pytest -q`
