### PR TITLE
Refactor parser handler mapping

### DIFF
--- a/src/common_patterns.py
+++ b/src/common_patterns.py
@@ -1,8 +1,22 @@
-import re
+"""Common regex patterns loaded from ``regex_config.yml``."""
 
-STEP_RE = re.compile(r"^(?:Étape|Etape|Step)\s*:\s*(.*)", re.IGNORECASE)
-ACTION_RESULT_RE = re.compile(
-    r"^Action\s*:\s*(.*?)\s*(?:R[ée]sultat|Resultat)\s*:?\s*(.*)",
-    re.IGNORECASE,
-)
-ACTION_ONLY_RE = re.compile(r"^Action\s*:\s*(.*)", re.IGNORECASE)
+from __future__ import annotations
+
+import os
+import re
+import yaml
+
+CONFIG_PATH = os.path.join(os.path.dirname(__file__), "regex_config.yml")
+SIMPLE_RULES_PATH = os.path.join(os.path.dirname(__file__), "simple_rules.yml")
+
+with open(CONFIG_PATH, encoding="utf-8") as f:
+    _PATTERNS = yaml.safe_load(f)
+
+with open(SIMPLE_RULES_PATH, encoding="utf-8") as f:
+    SIMPLE_RULES: list[dict[str, str]] = yaml.safe_load(f)
+
+STEP_RE = re.compile(_PATTERNS["step"], re.IGNORECASE)
+ACTION_RESULT_RE = re.compile(_PATTERNS["action_result"], re.IGNORECASE)
+ACTION_ONLY_RE = re.compile(_PATTERNS["action_only"], re.IGNORECASE)
+RESULT_ONLY_RE = re.compile(_PATTERNS["result_only"], re.IGNORECASE)
+COMMENT_RE = re.compile(_PATTERNS["comment"], re.IGNORECASE)

--- a/src/lexer.py
+++ b/src/lexer.py
@@ -1,7 +1,13 @@
 from dataclasses import dataclass
 from typing import Iterator, Optional
 
-from common_patterns import ACTION_ONLY_RE, ACTION_RESULT_RE, STEP_RE
+from common_patterns import (
+    ACTION_ONLY_RE,
+    ACTION_RESULT_RE,
+    RESULT_ONLY_RE,
+    STEP_RE,
+    COMMENT_RE,
+)
 
 @dataclass
 class Token:
@@ -17,6 +23,8 @@ def lex(text: str) -> Iterator[Token]:
     for lineno, line in enumerate(text.splitlines(), start=1):
         stripped = line.strip()
         if not stripped:
+            continue
+        if COMMENT_RE.match(stripped):
             continue
         m = STEP_RE.match(stripped)
         if m:
@@ -35,6 +43,10 @@ def lex(text: str) -> Iterator[Token]:
         m = ACTION_ONLY_RE.match(stripped)
         if m:
             yield Token("ACTION_ONLY", m.group(1).strip(), lineno, original=line)
+            continue
+        m = RESULT_ONLY_RE.match(stripped)
+        if m:
+            yield Token("RESULT_ONLY", m.group(1).strip(), lineno, original=line)
             continue
         yield Token("TEXT", stripped, lineno, original=line)
 

--- a/src/regex_config.yml
+++ b/src/regex_config.yml
@@ -1,0 +1,5 @@
+step: '^(?:Étape|Etape|Step)\s*:\s*(.*)$'
+action_result: '^Action\s*:\s*(.*?)\s*;\s*(?:R[ée]sultat|Resultat)\s*:\s*(.*)$'
+action_only: '^Action\s*:\s*(.*)$'
+result_only: '^R[ée]sultat\s*:\s*(.*)$'
+comment: '^\s*#.*$'

--- a/src/simple_rules.yml
+++ b/src/simple_rules.yml
@@ -1,0 +1,42 @@
+- pattern: '(créer|configurer)(?!.*(?:dossier|fichier|=)).*'
+  handler: initialization {0}
+- pattern: 'initialiser(?!.*?\.sql).*'
+  handler: initialization {0}
+- pattern: 'd\xE9finir la variable\s*(\S+)\s*=\s*(.+?)(?:;|$)'
+  handler: set_variable {1} {2}
+- pattern: 'exécuter.*?\.sql.*'
+  handler: sql_script {0}
+- pattern: '(?:exécuter|lancer|traiter)\s+(\S+\.sh).*'
+  handler: batch_script {1}
+- pattern: '(exécuter|lancer|traiter).*'
+  handler: execution {0}
+- pattern: '(?:vérifier|valider)\s+que\s+(.*)'
+  handler: validation {1}
+- pattern: '(logs|erreurs|fichiers de logs)'
+  handler: logs_check {0}
+- pattern: '(?:argument|paramètre|et\s+(?:l[''ae]|l''))\s*(\S+)=\s*(\S+)'
+  handler: arguments {1} {2}
+- pattern: 'd[ée]finir la variable\s+(\w+)\s*=\s*([^;]+)'
+  handler: variable {1} {2}
+- pattern: '(?:chemin|path) des logs\s*=\s*(\S+)'
+  handler: log_path {1}
+- pattern: 'script sql\s*=\s*(.*?\.sql)'
+  handler: sql_script_single {1}
+- pattern: '(cr[ée]er|mettre\s+(?:à|a)\s+jour)\s+(fichier|dossier)\s*=\s*(\S+)\s*(?:avec les droits|mode)\s*=\s*(\S+)'
+  handler: file_op {1} {2} {3} {4}
+- pattern: 'cr[ée]er\s+le\s+dossier\s*=?\s*(\S+)'
+  handler: create_dir {1}
+- pattern: 'cr[ée]er\s+le\s+fichier\s*=?\s*(\S+)'
+  handler: create_file {1}
+- pattern: 'mettre\s+(?:à|a)\s+jour\s+la\s+date\s+du\s+fichier\s*(\S+)\s*(\d{8,14})?'
+  handler: touch_date {1} {{2}}
+- pattern: 'touch(?:er)?(?:\s+le\s+fichier)?\s*(\S+)(?:\s+(?:-t\s*)?(\d{8,14}))?'
+  handler: touch {1} {{2}}
+- pattern: 'comparer\s+le\s+fichier\s*(\S+)\s+avec\s*(\S+)'
+  handler: compare_files {1} {2}
+- pattern: '(copier|d\xE9placer)\s+(?:le\s+)?(fichier|dossier)?\s*(\S+)\s+vers\s+(\S+)'
+  handler: copy_move {1} {{2}} {3} {4}
+- pattern: '(?:afficher le contenu du fichier|cat le fichier|lire le fichier)\s*=?\s*(\S+)'
+  handler: cat {1}
+- pattern: '(?:vider|purger)\s+le\s+(?:r[eé]pertoire|dossier)\s*=?\s*(\S+)'
+  handler: purge_dir {1}

--- a/src/verify_syntax.py
+++ b/src/verify_syntax.py
@@ -47,15 +47,20 @@ def check_file(path: str, parser: Parser) -> List[str]:
                 errors.append(f"{path}:{token.lineno}: ligne non reconnue -> {line}")
             continue
 
-        if token.kind in ("ACTION_RESULT", "ACTION_ONLY"):
+        if token.kind in ("ACTION_RESULT", "ACTION_ONLY", "RESULT_ONLY"):
             if current_step_lineno is None:
+                msg = (
+                    "action sans \u00e9tape"
+                    if token.kind != "RESULT_ONLY"
+                    else "r\u00e9sultat sans \u00e9tape"
+                )
                 errors.append(
-                    f"{path}:{token.lineno}: action sans \u00e9tape -> {token.original or token.value}"
+                    f"{path}:{token.lineno}: {msg} -> {token.original or token.value}"
                 )
             line = (
                 f"Action: {token.value} ; R\u00e9sultat: {token.result}"
                 if token.kind == "ACTION_RESULT"
-                else f"Action: {token.value}"
+                else f"Action: {token.value}" if token.kind == "ACTION_ONLY" else f"R\u00e9sultat: {token.value}"
             )
             actions = parser.parse(line)
             if _is_actions_empty(actions):

--- a/tests/unit/test_parser.py
+++ b/tests/unit/test_parser.py
@@ -20,10 +20,15 @@ class TestParser(unittest.TestCase):
         self.assertEqual(result["arguments"].get("fichier"), "test.txt")
 
     def test_action_result_parsing(self):
-        text = "Action: exécuter init.sql Résultat: le script retourne un code 0"
+        text = "Action: exécuter init.sql ; Résultat: le script retourne un code 0"
         result = self.parser.parse(text)
         self.assertIn("init.sql", result["sql_scripts"])
         self.assertIn("retour 0", result["validation"])
+
+    def test_ignore_comment(self):
+        text = "# ceci est un commentaire\nAction: echo test"
+        result = self.parser.parse(text)
+        self.assertEqual(result["execution"], [])
 
     def test_batch_path_detection(self):
         result = self.parser.parse("exécuter mon_script.sh")

--- a/tests/unit/test_verify_syntax.py
+++ b/tests/unit/test_verify_syntax.py
@@ -44,6 +44,14 @@ class TestVerifySyntax(unittest.TestCase):
             os.unlink(path)
         self.assertTrue(any('action sans étape' in e for e in errors))
 
+    def test_result_without_step(self):
+        path = self._write_temp("Résultat: retour 0\n")
+        try:
+            errors = verify_syntax.check_file(path, self.parser)
+        finally:
+            os.unlink(path)
+        self.assertTrue(any('résultat sans étape' in e for e in errors))
+
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
## Summary
- generate parser handlers dynamically from YAML patterns
- support placeholder groups with optional values
- update simple rules patterns to capture full lines

## Testing
- `pytest -q`
