### PR TITLE
Fix CLI dispatch

### DIFF
--- a/src/shtest_compiler/compile_expr.py
+++ b/src/shtest_compiler/compile_expr.py
@@ -2,13 +2,18 @@
 import argparse
 from shtest_compiler.compiler.compiler import compile_validation
 
+
+def compile_expr(expression: str, verbose: bool = False):
+    """Return shell instructions for the given validation expression."""
+    return compile_validation(expression, verbose=verbose)
+
 def main():
     parser = argparse.ArgumentParser(description="Compiler une expression de validation en shell.")
     parser.add_argument("expression", help="Expression à compiler, ex: 'fichier /tmp/x contient OK'")
     parser.add_argument("--verbose", action="store_true", help="Afficher les étapes de compilation")
 
     args = parser.parse_args()
-    lines = compile_validation(args.expression, verbose=args.verbose)
+    lines = compile_expr(args.expression, verbose=args.verbose)
     print("\n".join(lines))
 
 if __name__ == "__main__":

--- a/src/shtest_compiler/shtest.py
+++ b/src/shtest_compiler/shtest.py
@@ -1,7 +1,7 @@
 
 import argparse
-from shtest_compiler.compile_expr import main as compile_expr_main
-from shtest_compiler.compile_file import main as compile_file_main
+from shtest_compiler.compile_expr import compile_expr
+from shtest_compiler.compile_file import compile_file
 from shtest_compiler.generate_tests import generate_tests
 
 def main():
@@ -27,9 +27,16 @@ def main():
     args = parser.parse_args()
 
     if args.command == "compile_expr":
-        compile_expr_main()
+        lines = compile_expr(args.expression, verbose=args.verbose)
+        print("\n".join(lines))
     elif args.command == "compile_file":
-        compile_file_main()
+        lines = compile_file(args.file, verbose=args.verbose)
+        if args.output:
+            with open(args.output, "w", encoding="utf-8") as f:
+                f.write("\n".join(lines) + "\n")
+            print(f"[✔] Script sauvegardé dans {args.output}")
+        else:
+            print("\n".join(lines))
     elif args.command == "generate":
         generate_tests(args.input_dir, args.output_dir)
 


### PR DESCRIPTION
## Summary
- call compile_expr/compile_file functions from the main CLI
- expose a `compile_expr` helper for code reuse

## Testing
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_6870279750648331b9f215459ce5d6c5