### PR TITLE
Add CLI for syntax check

### DIFF
--- a/src/pyproject.toml
+++ b/src/pyproject.toml
@@ -10,6 +10,7 @@ requires-python = ">=3.8"
 compile_expr = "shtest_compiler.compile_expr:main"
 compile_file = "shtest_compiler.compile_file:main"
 shtest = "shtest_compiler.shtest:main"
+verify_syntax = "shtest_compiler.verify_syntax:main"
 
 [build-system]
 requires = ["setuptools>=61"]

--- a/src/shtest_compiler/verify_syntax.py
+++ b/src/shtest_compiler/verify_syntax.py
@@ -106,3 +106,44 @@ def check_file(path: str, parser: Parser) -> List[str]:
         )
 
     return errors
+
+
+def main() -> None:
+    """Point d'entrée CLI pour la vérification de syntaxe."""
+    import argparse
+    import os
+    import sys
+
+    parser = argparse.ArgumentParser(
+        description="Vérifie la syntaxe des fichiers .shtest"
+    )
+    parser.add_argument(
+        "path",
+        nargs="?",
+        default="tests",
+        help="Fichier ou dossier à analyser",
+    )
+    args = parser.parse_args()
+
+    parser_obj = Parser()
+    all_errors: List[str] = []
+
+    if os.path.isdir(args.path):
+        for name in os.listdir(args.path):
+            if name.endswith(".shtest"):
+                full = os.path.join(args.path, name)
+                print(f"Vérification de {full}")
+                all_errors.extend(check_file(full, parser_obj))
+    else:
+        print(f"Vérification de {args.path}")
+        all_errors.extend(check_file(args.path, parser_obj))
+
+    if all_errors:
+        print("\n".join(all_errors))
+        sys.exit("❌ Erreurs détectées")
+
+    print("✅ Syntaxe valide")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a `verify_syntax` entry point in `pyproject.toml`
- expose a new `main` function in `verify_syntax.py`
- allow running the module as a standalone CLI

## Testing
- `pip install -e src`
- `pytest -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68703cb1847483319bff341d7b90d3d7